### PR TITLE
Feat/#35/user module

### DIFF
--- a/application/interface.go
+++ b/application/interface.go
@@ -1,0 +1,8 @@
+package usecase
+
+type IUserUsecase interface {
+	SignUp(user CreateUserInput) (*createUserOutput, error)
+	Login(user loginUserInput) (*loginUserOutput, error)
+	GetUserSetting(userID string) (*getUserOutput, error)
+	UpdateSetting(user updateUserInput) (*updateUserOutput, error)
+}

--- a/application/user_usercase.go
+++ b/application/user_usercase.go
@@ -1,0 +1,154 @@
+package usecase
+
+import (
+	"os"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/google/uuid"
+	userDomain "github.com/minminseo/recall-setter/domain/user"
+)
+
+type CreateUserInput struct {
+	Email      string
+	Password   string
+	Timezone   string
+	ThemeColor string
+	Language   string
+}
+
+type createUserOutput struct {
+	ID    string
+	Email string
+}
+
+type loginUserInput struct {
+	Email    string
+	Password string
+}
+
+type loginUserOutput struct {
+	Token      string
+	ThemeColor string
+	Language   string
+}
+
+type getUserOutput struct {
+	Email      string
+	Timezone   string
+	ThemeColor string
+	Language   string
+}
+
+type updateUserInput struct {
+	ID         string
+	Email      string
+	Timezone   string
+	ThemeColor string
+	Language   string
+}
+
+type updateUserOutput struct {
+	Email      string
+	Timezone   string
+	ThemeColor string
+	Language   string
+}
+
+type userUsecase struct {
+	userRepo userDomain.UserRepository
+}
+
+func NewUserUsecase(userRepo userDomain.UserRepository) IUserUsecase {
+	return &userUsecase{userRepo: userRepo}
+}
+
+func (uu *userUsecase) SignUp(dto CreateUserInput) (*createUserOutput, error) {
+	id := uuid.NewString()
+
+	newUser, err := userDomain.NewUser(id, dto.Email, dto.Password, dto.Timezone, dto.ThemeColor, dto.Language)
+	if err != nil {
+		return nil, err
+	}
+
+	err = uu.userRepo.Create(newUser)
+	if err != nil {
+		return nil, err
+	}
+
+	resUser := &createUserOutput{
+		ID:    newUser.ID,
+		Email: newUser.Email,
+	}
+
+	return resUser, nil
+}
+
+func (uu *userUsecase) Login(dto loginUserInput) (*loginUserOutput, error) {
+	user, err := uu.userRepo.FindByEmail(dto.Email)
+	if err != nil {
+		return nil, err
+	}
+
+	err = user.IsValidPassword(dto.Password)
+	if err != nil {
+		return nil, err
+	}
+
+	// JWTトークン生成
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"user_id": user.ID,
+		"exp":     time.Now().Add(time.Hour * 12).Unix(),
+	})
+	tokenString, err := token.SignedString([]byte(os.Getenv("SECRET")))
+	if err != nil {
+		return nil, err
+	}
+
+	resUser := &loginUserOutput{
+		Token:      tokenString,
+		ThemeColor: user.ThemeColor,
+		Language:   user.Language,
+	}
+	return resUser, nil
+}
+
+func (uu *userUsecase) GetUserSetting(userID string) (*getUserOutput, error) {
+	user, err := uu.userRepo.GetSettingByID(userID)
+	if err != nil {
+		return nil, err
+	}
+	resUser := &getUserOutput{
+		Email:      user.Email,
+		Timezone:   user.Timezone,
+		ThemeColor: user.ThemeColor,
+		Language:   user.Language,
+	}
+	return resUser, nil
+}
+
+func (uu *userUsecase) UpdateSetting(user updateUserInput) (*updateUserOutput, error) {
+	targetUser, err := uu.userRepo.GetSettingByID(user.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	err = targetUser.Set(user.Email, user.Timezone, user.ThemeColor, user.Language)
+	if err != nil {
+		return nil, err
+	}
+
+	err = uu.userRepo.Update(targetUser)
+	if err != nil {
+		return nil, err
+	}
+
+	resUser := &updateUserOutput{
+		Email:      targetUser.Email,
+		Timezone:   targetUser.Timezone,
+		ThemeColor: targetUser.ThemeColor,
+		Language:   targetUser.Language,
+	}
+
+	return resUser, nil
+}

--- a/domain/user/user_repository.go
+++ b/domain/user/user_repository.go
@@ -3,5 +3,6 @@ package user
 type UserRepository interface {
 	Create(user *User) error
 	FindByEmail(email string) (*User, error)
+	GetSettingByID(userID string) (*User, error)
 	Update(user *User) error
 }

--- a/domain/user/user_test.go
+++ b/domain/user/user_test.go
@@ -1,0 +1,151 @@
+package user
+
+// ozzo-validationのis.Emailの条件
+/*
+"plainaddress",             // @ がない
+"@missingusername.com",     // ユーザー名がない
+"user@.com",                // ドメインがピリオドで始まる
+"user@com",                 // ドメインにピリオドがない
+"user..name@example.com",   // ローカル部に連続ドット
+".user@example.com",        // ローカル部がピリオドで始まる
+"user@example..com",        // ドメイン部に連続ドット
+"user@-example.com",        // ドメインラベルがハイフンで始まる
+"user@exam_ple.com",        // ドメインに許可されない文字（アンダースコア）
+7文字以上、254文字以下の長さがOK
+*/
+
+import (
+	"testing"
+)
+
+func TestNewUser(t *testing.T) {
+	tests := []struct {
+		name       string
+		id         string
+		email      string
+		password   string
+		timezone   string
+		themeColor string
+		language   string
+		wantErr    bool
+		errMsg     string
+	}{
+		// 正常系
+		{
+			name:       "valid input",
+			id:         "user1",
+			email:      "test@example.com",
+			password:   "secret123",
+			timezone:   TimeZoneTokyo,
+			themeColor: ThemeColorDark,
+			language:   LanguageJa,
+			wantErr:    false,
+		},
+
+		// 異常系
+		{
+			name:       "invalid email",
+			id:         "user2",
+			email:      "invalid-email",
+			password:   "secret123",
+			timezone:   TimeZoneTokyo,
+			themeColor: ThemeColorDark,
+			language:   LanguageJa,
+			wantErr:    true,
+			errMsg:     "メールアドレスを入力して下さい",
+		},
+
+		// 異常系
+		{
+			name:       "short password",
+			id:         "user3",
+			email:      "abcdefg@example.com",
+			password:   "123",
+			timezone:   TimeZoneTokyo,
+			themeColor: ThemeColorDark,
+			language:   LanguageJa,
+			wantErr:    true,
+			errMsg:     "パスワードは6文字以上です",
+		},
+
+		// 異常系
+		{
+			name:       "unsupported timezone",
+			id:         "user4",
+			email:      "abcdefg@example.com",
+			password:   "secret123",
+			timezone:   "Invalid/Zone",
+			themeColor: ThemeColorDark,
+			language:   LanguageJa,
+			wantErr:    true,
+			errMsg:     "タイムゾーンの値が不正です",
+		},
+		{
+			name:       "unsupported theme color",
+			id:         "user5",
+			email:      "abcdefg@example.com",
+			password:   "secret123",
+			timezone:   TimeZoneTokyo,
+			themeColor: "blue",
+			language:   LanguageJa,
+			wantErr:    true,
+			errMsg:     "テーマカラーは'dark'または'light'で指定してください",
+		},
+
+		// 異常系
+		{
+			name:       "unsupported language",
+			id:         "user6",
+			email:      "abcdefg@example.com",
+			password:   "secret123",
+			timezone:   TimeZoneTokyo,
+			themeColor: ThemeColorDark,
+			language:   "test",
+			wantErr:    true,
+			errMsg:     "言語タグの値が不正です",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := NewUser(tc.id, tc.email, tc.password, tc.timezone, tc.themeColor, tc.language)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error but got nil")
+				}
+				if err.Error() != tc.errMsg {
+					t.Errorf("unexpected error message: got %q, want %q", err.Error(), tc.errMsg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// フィールドのセットを確認
+			if u.ID != tc.id {
+				t.Errorf("ID: got %q, want %q", u.ID, tc.id)
+			}
+			if u.Email != tc.email {
+				t.Errorf("Email: got %q, want %q", u.Email, tc.email)
+			}
+			if u.Timezone != tc.timezone {
+				t.Errorf("Timezone: got %q, want %q", u.Timezone, tc.timezone)
+			}
+			if u.ThemeColor != tc.themeColor {
+				t.Errorf("ThemeColor: got %q, want %q", u.ThemeColor, tc.themeColor)
+			}
+			if u.Language != tc.language {
+				t.Errorf("Language: got %q, want %q", u.Language, tc.language)
+			}
+			// パスワードがハッシュ化されていること & IsValidPasswordで検証できること
+			if err := u.IsValidPassword(tc.password); err != nil {
+				t.Errorf("IsValidPassword returned error for correct password: %v", err)
+			}
+			if err := u.IsValidPassword("wrongpass"); err == nil {
+				t.Errorf("IsValidPassword did not return error for wrong password")
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,11 @@ module github.com/minminseo/recall-setter
 
 go 1.24.2
 
-require github.com/go-ozzo/ozzo-validation/v4 v4.3.0
+require (
+	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
+	github.com/golang-jwt/jwt/v4 v4.5.2
+	github.com/google/uuid v1.6.0
+	golang.org/x/crypto v0.38.0
+)
 
 require github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,11 +4,17 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-ozzo/ozzo-validation/v4 v4.3.0 h1:byhDUpfEwjsVQb1vBunvIjh2BHQ9ead57VkAEY4V+Es=
 github.com/go-ozzo/ozzo-validation/v4 v4.3.0/go.mod h1:2NKgrcHl3z6cJs+3Oo940FPRiTzuqKbvfrL2RxCj6Ew=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
+golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/infrastructure/db/query/user.sql
+++ b/infrastructure/db/query/user.sql
@@ -1,0 +1,42 @@
+-- name: CreateUser :exec
+INSERT INTO 
+    users (
+        id,
+        email,
+        password,
+        timezone,
+        theme_color,
+        language
+    ) VALUES (
+        sqlc.arg(id),
+        sqlc.arg(email),
+        sqlc.arg(password),
+        sqlc.arg(timezone),
+        sqlc.arg(theme_color),
+        sqlc.arg(language)
+    );
+
+--name: FindUserByEmail: one
+SELECT
+    id,
+    email,
+    password,
+    timezone,
+    theme_color,
+    language,
+FROM
+    users
+WHERE
+    email = sqlc.arg(email);
+
+--name: UpdateUser: exec
+UPDATE
+    users
+SET
+    email = sqlc.arg(email),
+    password = sqlc.arg(password),
+    timezone = sqlc.arg(timezone),
+    theme_color = sqlc.arg(theme_color),
+    language = sqlc.arg(language),
+WHERE
+    id = sqlc.arg(id);

--- a/infrastructure/db/query/user.sql
+++ b/infrastructure/db/query/user.sql
@@ -19,15 +19,24 @@ INSERT INTO
 --name: FindUserByEmail: one
 SELECT
     id,
-    email,
     password,
-    timezone,
     theme_color,
     language,
 FROM
     users
 WHERE
     email = sqlc.arg(email);
+
+--name: GetUserSettingByID: one
+SELECT
+    email,
+    timezone,
+    theme_color,
+    language
+FROM
+    users
+WHERE
+    id = sqlc.arg(id);
 
 --name: UpdateUser: exec
 UPDATE

--- a/migrations/000001_create_users_table.up.sql
+++ b/migrations/000001_create_users_table.up.sql
@@ -4,9 +4,9 @@ CREATE TABLE users (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     email VARCHAR(255) NOT NULL UNIQUE,
     password TEXT NOT NULL,
-    timezone VARCHAR(64) NOT NULL DEFAULT 'Asia/Tokyo',
-    theme_color theme_color_enum NOT NULL DEFAULT 'dark',
-    language VARCHAR(5) NOT NULL DEFAULT 'ja',
+    timezone VARCHAR(64) NOT NULL,
+    theme_color theme_color_enum NOT NULL,
+    language VARCHAR(5) NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 )

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -1,0 +1,15 @@
+version: "2"
+sql:
+  - engine: "postgresql"
+    queries: "./infrastructure/db/query/"
+    schema: "./migrations/"
+    gen:
+      go:
+        package: "dbgen"
+        out: "./infrastructure/db/dbgen"
+        sql_package: "pgx/v5"
+        emit_json_tags: true
+        emit_prepared_queries: true
+        emit_interfaces: true
+        emit_exact_table_names: false
+        emit_empty_slices: true


### PR DESCRIPTION
ユーザー系のユースケース層とsqlc設定もろもろ定義
# SQL系
DONE:
- sqlc.yaml設定
- コード生成用のクエリ定義

TODO:
- scheduled_review_datesの名前変えたほうが良いかも

# ユーザー系のユースケースの土台を定義
DONE:
- ユースケース層のメソッドのインターフェースを定義
- 基本的なuser系の制御を定義
- パスワードのハッシュ化と比較はドメイン層で定義した
- Validateメソッドはなくして、ozzo-validationを使ったバリデーションはカラム毎に分解して、適宜呼ぶ形にした。
    - 新規ユーザーオブジェクトの生成時と、ユーザー情報更新時のバリデーション内容がちょっと違うから分解した。
- パスワード変更は色々比較したりで処理ちょっと分厚そうだからUpdateSettingとは分けようかな。
TODO:
- パスワード変更のユースケース実装