### PR TITLE
feat: ボックス単位の完了済み復習物一覧取得機能実装。

### DIFF
--- a/controller/item/item_controller.go
+++ b/controller/item/item_controller.go
@@ -416,3 +416,47 @@ func (ic *itemController) GetAllDailyReviewDates(c echo.Context) error {
 	}
 	return c.JSON(http.StatusOK, result)
 }
+
+func (ic *itemController) GetFinishedItemsByBoxID(c echo.Context) error {
+	ctx := c.Request().Context()
+	userID, err := getUserIDFromContext(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, echo.Map{"error": "トークンにユーザーIDが含まれていません"})
+	}
+	boxID := c.Param("box_id")
+
+	out, err := ic.iu.GetFinishedItemsByBoxID(ctx, boxID, userID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "ボックス内の完了した復習物取得に失敗しました: " + err.Error()})
+	}
+	return c.JSON(http.StatusOK, out)
+}
+
+func (ic *itemController) GetUnclassfiedFinishedItemsByCategoryID(c echo.Context) error {
+	ctx := c.Request().Context()
+	userID, err := getUserIDFromContext(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, echo.Map{"error": "トークンにユーザーIDが含まれていません"})
+	}
+	categoryID := c.Param("category_id")
+
+	out, err := ic.iu.GetUnclassfiedFinishedItemsByCategoryID(ctx, userID, categoryID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "カテゴリ内の未分類完了復習物取得に失敗しました: " + err.Error()})
+	}
+	return c.JSON(http.StatusOK, out)
+}
+
+func (ic *itemController) GetUnclassfiedFinishedItemsByUserID(c echo.Context) error {
+	ctx := c.Request().Context()
+	userID, err := getUserIDFromContext(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, echo.Map{"error": "トークンにユーザーIDが含まれていません"})
+	}
+
+	out, err := ic.iu.GetUnclassfiedFinishedItemsByUserID(ctx, userID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "完了した復習物取得に失敗しました: " + err.Error()})
+	}
+	return c.JSON(http.StatusOK, out)
+}

--- a/controller/item/item_interface.go
+++ b/controller/item/item_interface.go
@@ -27,4 +27,8 @@ type IItemController interface {
 	CountAllDailyReviewDates(c echo.Context) error
 
 	GetAllDailyReviewDates(c echo.Context) error
+
+	GetFinishedItemsByBoxID(c echo.Context) error
+	GetUnclassfiedFinishedItemsByCategoryID(c echo.Context) error
+	GetUnclassfiedFinishedItemsByUserID(c echo.Context) error
 }

--- a/domain/item/item_repository.go
+++ b/domain/item/item_repository.go
@@ -133,6 +133,11 @@ type IItemRepository interface {
 
 	GetAllDailyReviewDates(ctx context.Context, userID string, parsedToday time.Time) ([]*DailyReviewDate, error)
 
+	// 完了済み復習物系を取得する系
+	GetFinishedItemsByBoxID(ctx context.Context, boxID string, userID string) ([]*Item, error)
+	GetUnclassfiedFinishedItemsByCategoryID(ctx context.Context, userID string, categoryID string) ([]*Item, error)
+	GetUnclassfiedFinishedItemsByUserID(ctx context.Context, userID string) ([]*Item, error)
+
 	/*--------------------*/
 	// patternパッケージで使うメソッド
 	IsPatternRelatedToItemByPatternID(ctx context.Context, patternID string, userID string) (bool, error)

--- a/infrastructure/db/dbgen/querier.go
+++ b/infrastructure/db/dbgen/querier.go
@@ -67,6 +67,8 @@ type Querier interface {
 	GetCategoryNamesByCategoryIDs(ctx context.Context, categoryIds []pgtype.UUID) ([]GetCategoryNamesByCategoryIDsRow, error)
 	// EditedAt取得専用
 	GetEditedAtByItemID(ctx context.Context, arg GetEditedAtByItemIDParams) (pgtype.Timestamptz, error)
+	// ボックス内画面用の完了の全復習物一覧取得系（復習物（親）のみ一覧取得）
+	GetFinishedItemsByBoxID(ctx context.Context, arg GetFinishedItemsByBoxIDParams) ([]GetFinishedItemsByBoxIDRow, error)
 	// 学習日変更など、どういうリクエストなのかを判定するために使う
 	GetItemByID(ctx context.Context, arg GetItemByIDParams) (GetItemByIDRow, error)
 	// 復習パターンそのものが更新対象かどうか判定するために使う
@@ -79,6 +81,8 @@ type Querier interface {
 	// 復習日Upate処理用。ReviewDateIDを使い回すために使う
 	GetReviewDateIDsByItemID(ctx context.Context, arg GetReviewDateIDsByItemIDParams) ([]pgtype.UUID, error)
 	GetReviewDatesByItemID(ctx context.Context, arg GetReviewDatesByItemIDParams) ([]GetReviewDatesByItemIDRow, error)
+	GetUnclassfiedFinishedItemsByCategoryID(ctx context.Context, arg GetUnclassfiedFinishedItemsByCategoryIDParams) ([]GetUnclassfiedFinishedItemsByCategoryIDRow, error)
+	GetUnclassfiedFinishedItemsByUserID(ctx context.Context, userID pgtype.UUID) ([]GetUnclassfiedFinishedItemsByUserIDRow, error)
 	GetUserSettingByID(ctx context.Context, id pgtype.UUID) (GetUserSettingByIDRow, error)
 	// 完了済みの復習日がないか判別するためのクエリ
 	HasCompletedReviewDateByItemID(ctx context.Context, arg HasCompletedReviewDateByItemIDParams) (bool, error)

--- a/infrastructure/db/query/item.sql
+++ b/infrastructure/db/query/item.sql
@@ -235,6 +235,8 @@ FROM
 WHERE
     box_id = sqlc.arg(box_id)
 AND
+    is_Finished = false
+AND
     user_id = sqlc.arg(user_id)
 ORDER BY
     registered_at;
@@ -548,3 +550,81 @@ ORDER BY
     ri.registered_at;
 
 
+
+-- ボックス内画面用の完了の全復習物一覧取得系（復習物（親）のみ一覧取得）
+-- name: GetFinishedItemsByBoxID :many
+SELECT
+    id,
+    user_id,
+    category_id,
+    box_id,
+    pattern_id,
+    name,
+    detail,
+    learned_date,
+    is_Finished,
+    registered_at,
+    edited_at
+FROM
+    review_items
+WHERE
+    box_id = sqlc.arg(box_id)
+AND
+    is_Finished = true
+AND
+    user_id = sqlc.arg(user_id)
+ORDER BY
+    registered_at;
+
+
+-- name: GetUnclassfiedFinishedItemsByCategoryID :many
+SELECT
+    id,
+    user_id,
+    category_id,
+    box_id,
+    pattern_id,
+    name,
+    detail,
+    learned_date,
+    is_Finished,
+    registered_at,
+    edited_at
+FROM
+    review_items
+WHERE
+    category_id = sqlc.arg(category_id)
+AND
+    user_id = sqlc.arg(user_id)
+AND
+    box_id IS NULL
+AND
+    is_Finished = true
+ORDER BY
+    registered_at;
+
+-- name: GetUnclassfiedFinishedItemsByUserID :many
+SELECT
+    id,
+    user_id,
+    category_id,
+    box_id,
+    pattern_id,
+    name,
+    detail,
+    learned_date,
+    is_Finished,
+    registered_at,
+    edited_at
+FROM
+    review_items
+WHERE
+    user_id = sqlc.arg(user_id)
+AND
+    category_id IS NULL
+AND
+    box_id IS NULL
+AND
+    is_Finished = true
+ORDER BY
+    registered_at;

--- a/usecase/item/interface.go
+++ b/usecase/item/interface.go
@@ -33,4 +33,9 @@ type IItemUsecase interface {
 
 	// 今日の復習日一覧を取得する
 	GetAllDailyReviewDates(ctx context.Context, userID string, today string) (*GetDailyReviewDatesOutput, error)
+
+	// 完了済み復習物を取得する系
+	GetFinishedItemsByBoxID(ctx context.Context, boxID string, userID string) ([]*GetItemOutput, error)
+	GetUnclassfiedFinishedItemsByCategoryID(ctx context.Context, userID string, categoryID string) ([]*GetItemOutput, error)
+	GetUnclassfiedFinishedItemsByUserID(ctx context.Context, userID string) ([]*GetItemOutput, error)
 }

--- a/usecase/item/item_usecase.go
+++ b/usecase/item/item_usecase.go
@@ -1264,3 +1264,178 @@ func (iu *ItemUsecase) GetAllDailyReviewDates(ctx context.Context, userID string
 	}
 	return out, nil
 }
+
+// 完了済み復習物取得系
+func (iu *ItemUsecase) GetFinishedItemsByBoxID(ctx context.Context, boxID string, userID string) ([]*GetItemOutput, error) {
+	items, err := iu.itemRepo.GetFinishedItemsByBoxID(ctx, boxID, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	// アイテムIDをキーに完了済みアイテムをマップ化
+	finishedItemMap := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		finishedItemMap[item.ItemID] = struct{}{}
+	}
+
+	// 全復習日を取得
+	reviewdates, err := iu.itemRepo.GetAllReviewDatesByBoxID(ctx, boxID, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 完了済みアイテムを親に持つ復習日のみ抽出
+	reviewdatesByItem := make(map[string][]GetReviewDateOutput, len(items))
+
+	for _, reviewdate := range reviewdates {
+		if _, ok := finishedItemMap[reviewdate.ItemID]; !ok {
+			continue
+		}
+		reviewdatesByItem[reviewdate.ItemID] = append(reviewdatesByItem[reviewdate.ItemID], GetReviewDateOutput{
+			ReviewDateID:         reviewdate.ReviewdateID,
+			UserID:               reviewdate.UserID,
+			CategoryID:           reviewdate.CategoryID,
+			BoxID:                reviewdate.BoxID,
+			ItemID:               reviewdate.ItemID,
+			StepNumber:           reviewdate.StepNumber,
+			InitialScheduledDate: reviewdate.InitialScheduledDate.Format("2006-01-02"),
+			ScheduledDate:        reviewdate.ScheduledDate.Format("2006-01-02"),
+			IsCompleted:          reviewdate.IsCompleted,
+		})
+	}
+
+	result := make([]*GetItemOutput, 0, len(items))
+	for _, item := range items {
+		result = append(result, &GetItemOutput{
+			ItemID:       item.ItemID,
+			UserID:       item.UserID,
+			CategoryID:   item.CategoryID,
+			BoxID:        item.BoxID,
+			PatternID:    item.PatternID,
+			Name:         item.Name,
+			Detail:       item.Detail,
+			LearnedDate:  item.LearnedDate.Format("2006-01-02"),
+			IsFinished:   item.IsFinished,
+			RegisteredAt: item.RegisteredAt,
+			EditedAt:     item.EditedAt,
+			ReviewDates:  reviewdatesByItem[item.ItemID],
+		})
+	}
+	return result, nil
+}
+
+func (iu *ItemUsecase) GetUnclassfiedFinishedItemsByCategoryID(ctx context.Context, userID string, categoryID string) ([]*GetItemOutput, error) {
+	items, err := iu.itemRepo.GetUnclassfiedFinishedItemsByCategoryID(ctx, userID, categoryID)
+	if err != nil {
+		return nil, err
+	}
+
+	// アイテムIDをキーに完了済みアイテムをマップ化
+	finishedItemMap := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		finishedItemMap[item.ItemID] = struct{}{}
+	}
+
+	// 全復習日を取得
+	reviewdates, err := iu.itemRepo.GetAllUnclassifiedReviewDatesByCategoryID(ctx, categoryID, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 完了済みアイテムを親に持つ復習日のみ抽出
+	reviewdatesByItem := make(map[string][]GetReviewDateOutput, len(items))
+
+	for _, reviewdate := range reviewdates {
+		if _, ok := finishedItemMap[reviewdate.ItemID]; !ok {
+			continue
+		}
+		reviewdatesByItem[reviewdate.ItemID] = append(reviewdatesByItem[reviewdate.ItemID], GetReviewDateOutput{
+			ReviewDateID:         reviewdate.ReviewdateID,
+			UserID:               reviewdate.UserID,
+			CategoryID:           reviewdate.CategoryID,
+			BoxID:                reviewdate.BoxID,
+			ItemID:               reviewdate.ItemID,
+			StepNumber:           reviewdate.StepNumber,
+			InitialScheduledDate: reviewdate.InitialScheduledDate.Format("2006-01-02"),
+			ScheduledDate:        reviewdate.ScheduledDate.Format("2006-01-02"),
+			IsCompleted:          reviewdate.IsCompleted,
+		})
+	}
+
+	result := make([]*GetItemOutput, 0, len(items))
+	for _, item := range items {
+		result = append(result, &GetItemOutput{
+			ItemID:       item.ItemID,
+			UserID:       item.UserID,
+			CategoryID:   item.CategoryID,
+			BoxID:        item.BoxID,
+			PatternID:    item.PatternID,
+			Name:         item.Name,
+			Detail:       item.Detail,
+			LearnedDate:  item.LearnedDate.Format("2006-01-02"),
+			IsFinished:   item.IsFinished,
+			RegisteredAt: item.RegisteredAt,
+			EditedAt:     item.EditedAt,
+			ReviewDates:  reviewdatesByItem[item.ItemID],
+		})
+	}
+	return result, nil
+}
+
+func (iu *ItemUsecase) GetUnclassfiedFinishedItemsByUserID(ctx context.Context, userID string) ([]*GetItemOutput, error) {
+	items, err := iu.itemRepo.GetUnclassfiedFinishedItemsByUserID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	// アイテムIDをキーに完了済みアイテムをマップ化
+	finishedItemMap := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		finishedItemMap[item.ItemID] = struct{}{}
+	}
+
+	// 全復習日を取得
+	reviewdates, err := iu.itemRepo.GetAllUnclassifiedReviewDatesByUserID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 完了済みアイテムを親に持つ復習日のみ抽出
+	reviewdatesByItem := make(map[string][]GetReviewDateOutput, len(items))
+
+	for _, reviewdate := range reviewdates {
+		if _, ok := finishedItemMap[reviewdate.ItemID]; !ok {
+			continue
+		}
+		reviewdatesByItem[reviewdate.ItemID] = append(reviewdatesByItem[reviewdate.ItemID], GetReviewDateOutput{
+			ReviewDateID:         reviewdate.ReviewdateID,
+			UserID:               reviewdate.UserID,
+			CategoryID:           reviewdate.CategoryID,
+			BoxID:                reviewdate.BoxID,
+			ItemID:               reviewdate.ItemID,
+			StepNumber:           reviewdate.StepNumber,
+			InitialScheduledDate: reviewdate.InitialScheduledDate.Format("2006-01-02"),
+			ScheduledDate:        reviewdate.ScheduledDate.Format("2006-01-02"),
+			IsCompleted:          reviewdate.IsCompleted,
+		})
+	}
+
+	result := make([]*GetItemOutput, 0, len(items))
+	for _, item := range items {
+		result = append(result, &GetItemOutput{
+			ItemID:       item.ItemID,
+			UserID:       item.UserID,
+			CategoryID:   item.CategoryID,
+			BoxID:        item.BoxID,
+			PatternID:    item.PatternID,
+			Name:         item.Name,
+			Detail:       item.Detail,
+			LearnedDate:  item.LearnedDate.Format("2006-01-02"),
+			IsFinished:   item.IsFinished,
+			RegisteredAt: item.RegisteredAt,
+			EditedAt:     item.EditedAt,
+			ReviewDates:  reviewdatesByItem[item.ItemID],
+		})
+	}
+	return result, nil
+}


### PR DESCRIPTION
DONE:
- 以下の3パターンでボックス単位で完了済み復習物を取得するメソッドを実装。復習物、復習日の2回にわけて取得し、アプリロジックで結合。完了済み復習物の方は新しく3つのリポジトリメソッドを実装し、復習日の方は復習物ボックスで復習物を一覧取得する時に使ったメソッドを使いまわした。
　- category_idがNULLかつbox_idがNULL
　- category_idが非NULLかつbox_idがNULL
　- category_idが非NULLかつbox_idが非NULL

