### PR TITLE
feat: UpdateItemAsUnFinishedForceに未完了復習日調整ロジック追加

### DIFF
--- a/controller/item/item_controller.go
+++ b/controller/item/item_controller.go
@@ -242,7 +242,21 @@ func (ic *itemController) UpdateItemAsUnFinishedForce(c echo.Context) error {
 	}
 	itemID := c.Param("item_id")
 
-	input := itemUsecase.UpdateItemAsUnFinishedForceInput{ItemID: itemID, UserID: userID}
+	var req UpdateItemAsUnFinishedForceRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, echo.Map{"error": "リクエストの形式が正しくありません: " + err.Error()})
+	}
+
+	input := itemUsecase.UpdateItemAsUnFinishedForceInput{
+		ItemID:      itemID,
+		UserID:      userID,
+		CategoryID:  req.CategoryID,
+		BoxID:       req.BoxID,
+		PatternID:   req.PatternID,
+		LearnedDate: req.LearnedDate,
+		Today:       req.Today,
+	}
+
 	out, err := ic.iu.UpdateItemAsUnFinishedForce(ctx, input)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "復習物の再開処理に失敗しました: " + err.Error()})

--- a/controller/item/request.go
+++ b/controller/item/request.go
@@ -36,6 +36,14 @@ type UpdateReviewDatesRequest struct {
 	BoxID                    *string                 `json:"box_id"`
 }
 
+type UpdateItemAsUnFinishedForceRequest struct {
+	CategoryID  *string `json:"category_id"`
+	BoxID       *string `json:"box_id"`
+	PatternID   string  `json:"pattern_id"`
+	LearnedDate string  `json:"learned_date"`
+	Today       string  `json:"today"`
+}
+
 type PatternStepForRequest struct {
 	PatternStepID string `json:"pattern_step_id"`
 	UserID        string `json:"user_id"`

--- a/usecase/item/item_dto.go
+++ b/usecase/item/item_dto.go
@@ -96,15 +96,21 @@ type UpdateItemAsFinishedForceOutput struct {
 
 // 途中完了した復習物の再開リクエスト用のDTO
 type UpdateItemAsUnFinishedForceInput struct {
-	ItemID string
-	UserID string
+	ItemID      string
+	UserID      string
+	CategoryID  *string // nilなら未分類
+	BoxID       *string // nilなら未分類
+	PatternID   string  // 完了済みボックスの時点で必ずある
+	LearnedDate string  // 計算用
+	Today       string
 }
 
 type UpdateItemAsUnFinishedForceOutput struct {
-	ItemID     string
-	UserID     string
-	IsFinished bool
-	EditedAt   time.Time
+	ItemID      string
+	UserID      string
+	IsFinished  bool
+	EditedAt    time.Time
+	ReviewDates []UpdateReviewDateOutput // 復習物更新のDTO共有
 }
 
 type UpdateReviewDateAsCompletedInput struct {


### PR DESCRIPTION
DONE:
- UpdateItemAsUnFinishedForceはこれまで単にrevie_itemsのis_finishedをfalseにするだけだったが、true中（途中完了中）は未完了復習日は今日に自動スライドされないので、UpdateItemAsUnFinishedForceでis_finishedをfalseにしたときに、未完了復習日<今日の場合、その未完了復習日を今日以降にスライドする必要があったのでそのロジックを追加。