### PR TITLE
fix: FindByEmailの返り値としてVerifiedAtを扱えるように修正

### DIFF
--- a/infrastructure/db/dbgen/user.sql.go
+++ b/infrastructure/db/dbgen/user.sql.go
@@ -56,7 +56,8 @@ SELECT
     id,
     password,
     theme_color,
-    language
+    language,
+    verified_at
 FROM
     users
 WHERE
@@ -64,10 +65,11 @@ WHERE
 `
 
 type FindUserByEmailRow struct {
-	ID         pgtype.UUID    `json:"id"`
-	Password   string         `json:"password"`
-	ThemeColor ThemeColorEnum `json:"theme_color"`
-	Language   string         `json:"language"`
+	ID         pgtype.UUID        `json:"id"`
+	Password   string             `json:"password"`
+	ThemeColor ThemeColorEnum     `json:"theme_color"`
+	Language   string             `json:"language"`
+	VerifiedAt pgtype.Timestamptz `json:"verified_at"`
 }
 
 func (q *Queries) FindUserByEmail(ctx context.Context, email string) (FindUserByEmailRow, error) {
@@ -78,6 +80,7 @@ func (q *Queries) FindUserByEmail(ctx context.Context, email string) (FindUserBy
 		&i.Password,
 		&i.ThemeColor,
 		&i.Language,
+		&i.VerifiedAt,
 	)
 	return i, err
 }

--- a/infrastructure/db/query/user.sql
+++ b/infrastructure/db/query/user.sql
@@ -21,7 +21,8 @@ SELECT
     id,
     password,
     theme_color,
-    language
+    language,
+    verified_at
 FROM
     users
 WHERE

--- a/infrastructure/repository/user_repository.go
+++ b/infrastructure/repository/user_repository.go
@@ -54,12 +54,18 @@ func (r *userRepository) FindByEmail(ctx context.Context, email string) (*userDo
 	}
 	id := uuid.UUID(row.ID.Bytes).String()
 
+	var verifiedAt *time.Time
+	if row.VerifiedAt.Valid {
+		verifiedAt = &row.VerifiedAt.Time
+	}
+
 	return &userDomain.User{
 		ID:                id,
 		Email:             email,
 		EncryptedPassword: row.Password,
 		ThemeColor:        string(row.ThemeColor),
 		Language:          row.Language,
+		VerifiedAt:        verifiedAt,
 	}, nil
 }
 


### PR DESCRIPTION
DONE:
- userドメインのFindByEmailクエリでverifie_atを取得するように修正。
- user_repository.goのFindByEmailでVeifiedAtを*time.Time型にキャストして返すように修正

これらの修正により正常にログインできるようにした