### PR TITLE
Fix/#93/response

### DIFF
--- a/controller/box/box_controller.go
+++ b/controller/box/box_controller.go
@@ -47,7 +47,17 @@ func (bc *boxController) CreateBox(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "ボックスの作成に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusCreated, boxRes)
+	res := BoxResponse{
+		ID:           boxRes.ID,
+		UserID:       boxRes.UserID,
+		CategoryID:   boxRes.CategoryID,
+		PatternID:    boxRes.PatternID,
+		Name:         boxRes.Name,
+		RegisteredAt: boxRes.RegisteredAt,
+		EditedAt:     boxRes.EditedAt,
+	}
+	return c.JSON(http.StatusCreated, res)
+
 }
 
 func (bc *boxController) GetBoxes(c echo.Context) error {
@@ -70,7 +80,19 @@ func (bc *boxController) GetBoxes(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "ボックス一覧の取得に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, boxesRes)
+	var res []BoxResponse
+	for _, b := range boxesRes {
+		res = append(res, BoxResponse{
+			ID:           b.ID,
+			UserID:       b.UserID,
+			CategoryID:   b.CategoryID,
+			PatternID:    b.PatternID,
+			Name:         b.Name,
+			RegisteredAt: b.RegisteredAt,
+			EditedAt:     b.EditedAt,
+		})
+	}
+	return c.JSON(http.StatusOK, res)
 }
 
 func (bc *boxController) UpdateBox(c echo.Context) error {
@@ -103,9 +125,17 @@ func (bc *boxController) UpdateBox(c echo.Context) error {
 		PatternID:  req.PatternID,
 		Name:       req.Name,
 	}
-	res, err := bc.bu.UpdateBox(ctx, input)
+	boxRes, err := bc.bu.UpdateBox(ctx, input)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "ボックスの更新に失敗しました: " + err.Error()})
+	}
+	res := UpdateBoxResponse{
+		ID:         boxRes.ID,
+		UserID:     boxRes.UserID,
+		CategoryID: boxRes.CategoryID,
+		PatternID:  boxRes.PatternID,
+		Name:       boxRes.Name,
+		EditedAt:   boxRes.EditedAt,
 	}
 	return c.JSON(http.StatusOK, res)
 }

--- a/controller/box/response.go
+++ b/controller/box/response.go
@@ -1,0 +1,22 @@
+package box
+
+import "time"
+
+type BoxResponse struct {
+	ID           string    `json:"id"`
+	UserID       string    `json:"user_id"`
+	CategoryID   string    `json:"category_id"`
+	PatternID    string    `json:"pattern_id"`
+	Name         string    `json:"name"`
+	RegisteredAt time.Time `json:"registered_at"`
+	EditedAt     time.Time `json:"edited_at"`
+}
+
+type UpdateBoxResponse struct {
+	ID         string    `json:"id"`
+	UserID     string    `json:"user_id"`
+	CategoryID string    `json:"category_id"`
+	PatternID  string    `json:"pattern_id"`
+	Name       string    `json:"name"`
+	EditedAt   time.Time `json:"edited_at"`
+}

--- a/controller/category/category_controller.go
+++ b/controller/category/category_controller.go
@@ -44,7 +44,15 @@ func (cc *categoryController) CreateCategory(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "カテゴリの作成に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusCreated, categoryRes)
+	res := CategoryResponse{
+		ID:           categoryRes.ID,
+		UserID:       categoryRes.UserID,
+		Name:         categoryRes.Name,
+		RegisteredAt: categoryRes.RegisteredAt,
+		EditedAt:     categoryRes.EditedAt,
+	}
+	return c.JSON(http.StatusCreated, res)
+
 }
 
 func (cc *categoryController) GetCategories(c echo.Context) error {
@@ -65,7 +73,19 @@ func (cc *categoryController) GetCategories(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "カテゴリの取得に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, categoriesRes)
+
+	var res []CategoryResponse
+	for _, cat := range categoriesRes {
+		res = append(res, CategoryResponse{
+			ID:           cat.ID,
+			UserID:       cat.UserID,
+			Name:         cat.Name,
+			RegisteredAt: cat.RegisteredAt,
+			EditedAt:     cat.EditedAt,
+		})
+	}
+
+	return c.JSON(http.StatusOK, res)
 }
 
 func (cc *categoryController) UpdateCategory(c echo.Context) error {
@@ -102,7 +122,15 @@ func (cc *categoryController) UpdateCategory(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "カテゴリの更新に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, categoryRes)
+
+	res := UpdateCategoryResponse{
+		ID:       categoryRes.ID,
+		UserID:   categoryRes.UserID,
+		Name:     categoryRes.Name,
+		EditedAt: categoryRes.EditedAt,
+	}
+	return c.JSON(http.StatusOK, res)
+
 }
 
 func (cc *categoryController) DeleteCategory(c echo.Context) error {

--- a/controller/category/response.go
+++ b/controller/category/response.go
@@ -1,0 +1,18 @@
+package category
+
+import "time"
+
+type CategoryResponse struct {
+	ID           string    `json:"id"`
+	UserID       string    `json:"user_id"`
+	Name         string    `json:"name"`
+	RegisteredAt time.Time `json:"registered_at"`
+	EditedAt     time.Time `json:"edited_at"`
+}
+
+type UpdateCategoryResponse struct {
+	ID       string    `json:"id"`
+	UserID   string    `json:"user_id"`
+	Name     string    `json:"name"`
+	EditedAt time.Time `json:"edited_at"`
+}

--- a/controller/item/item_controller.go
+++ b/controller/item/item_controller.go
@@ -64,7 +64,36 @@ func (ic *itemController) CreateItem(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "復習物の作成に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusCreated, out)
+	reviewDates := make([]ReviewDateResponse, len(out.Reviewdates))
+	for i, rd := range out.Reviewdates {
+		reviewDates[i] = ReviewDateResponse{
+			ReviewDateID:         rd.DateID,
+			UserID:               rd.UserID,
+			ItemID:               rd.ItemID,
+			StepNumber:           rd.StepNumber,
+			InitialScheduledDate: rd.InitialScheduledDate,
+			ScheduledDate:        rd.ScheduledDate,
+			IsCompleted:          rd.IsCompleted,
+		}
+	}
+
+	res := ItemResponse{
+		ItemID:       out.ItemID,
+		UserID:       out.UserID,
+		CategoryID:   out.CategoryID,
+		BoxID:        out.BoxID,
+		PatternID:    out.PatternID,
+		Name:         out.Name,
+		Detail:       out.Detail,
+		LearnedDate:  out.LearnedDate,
+		IsFinished:   out.IsCompleted,
+		RegisteredAt: out.RegisteredAt,
+		EditedAt:     out.EditedAt,
+		ReviewDates:  reviewDates,
+	}
+
+	return c.JSON(http.StatusCreated, res)
+
 }
 
 func (ic *itemController) UpdateItem(c echo.Context) error {
@@ -100,7 +129,37 @@ func (ic *itemController) UpdateItem(c echo.Context) error {
 		}
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "復習物の更新に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, out)
+	reviewDates := make([]ReviewDateResponse, len(out.ReviewDates))
+	for i, rd := range out.ReviewDates {
+		reviewDates[i] = ReviewDateResponse{
+			ReviewDateID:         rd.ReviewDateID,
+			UserID:               rd.UserID,
+			CategoryID:           rd.CategoryID,
+			BoxID:                rd.BoxID,
+			ItemID:               rd.ItemID,
+			StepNumber:           rd.StepNumber,
+			InitialScheduledDate: rd.InitialScheduledDate,
+			ScheduledDate:        rd.ScheduledDate,
+			IsCompleted:          rd.IsCompleted,
+		}
+	}
+
+	res := ItemResponse{
+		ItemID:      out.ItemID,
+		UserID:      out.UserID,
+		CategoryID:  out.CategoryID,
+		BoxID:       out.BoxID,
+		PatternID:   out.PatternID,
+		Name:        out.Name,
+		Detail:      out.Detail,
+		LearnedDate: out.LearnedDate,
+		IsFinished:  out.IsFinished,
+		EditedAt:    out.EditedAt,
+		ReviewDates: reviewDates,
+	}
+
+	return c.JSON(http.StatusOK, res)
+
 }
 
 func (ic *itemController) DeleteItem(c echo.Context) error {
@@ -159,7 +218,30 @@ func (ic *itemController) UpdateReviewDates(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "復習日の更新に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, out)
+	reviewDates := make([]ReviewDateResponse, len(out.ReviewDates))
+	for i, rd := range out.ReviewDates {
+		reviewDates[i] = ReviewDateResponse{
+			ReviewDateID:         rd.ReviewDateID,
+			UserID:               rd.UserID,
+			CategoryID:           rd.CategoryID,
+			BoxID:                rd.BoxID,
+			ItemID:               rd.ItemID,
+			StepNumber:           rd.StepNumber,
+			InitialScheduledDate: rd.InitialScheduledDate,
+			ScheduledDate:        rd.ScheduledDate,
+			IsCompleted:          rd.IsCompleted,
+		}
+	}
+
+	res := UpdateBackReviewDateResponse{
+		ItemID:      out.ItemID,
+		UserID:      out.UserID,
+		IsFinished:  out.IsFinished,
+		EditedAt:    out.EditedAt,
+		ReviewDates: reviewDates,
+	}
+	return c.JSON(http.StatusOK, res)
+
 }
 
 func (ic *itemController) UpdateItemAsFinishedForce(c echo.Context) error {
@@ -175,7 +257,15 @@ func (ic *itemController) UpdateItemAsFinishedForce(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "復習物の完了処理に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, out)
+	res := UpdateItemAsFinishedForceResponse{
+		ItemID:     out.ItemID,
+		UserID:     out.UserID,
+		IsFinished: out.IsFinished,
+		EditedAt:   out.EditedAt,
+	}
+
+	return c.JSON(http.StatusOK, res)
+
 }
 
 func (ic *itemController) UpdateReviewDateAsCompleted(c echo.Context) error {
@@ -203,7 +293,16 @@ func (ic *itemController) UpdateReviewDateAsCompleted(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "復習日の完了処理に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, out)
+	res := UpdateReviewDateAsCompletedResponse{
+		ReviewDateID: out.ReviewDateID,
+		UserID:       out.UserID,
+		IsCompleted:  out.IsCompleted,
+		IsFinished:   out.IsFinished,
+		EditedAt:     out.EditedAt,
+	}
+
+	return c.JSON(http.StatusOK, res)
+
 }
 
 func (ic *itemController) UpdateReviewDateAsInCompleted(c echo.Context) error {
@@ -231,7 +330,14 @@ func (ic *itemController) UpdateReviewDateAsInCompleted(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "復習日の未完了処理に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, out)
+	res := UpdateReviewDateAsInCompletedResponse{
+		ReviewDateID: out.ReviewDateID,
+		UserID:       out.UserID,
+		IsCompleted:  out.IsCompleted,
+		IsFinished:   out.IsFinished,
+		EditedAt:     out.EditedAt,
+	}
+	return c.JSON(http.StatusOK, res)
 }
 
 func (ic *itemController) UpdateItemAsUnFinishedForce(c echo.Context) error {
@@ -261,7 +367,31 @@ func (ic *itemController) UpdateItemAsUnFinishedForce(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "復習物の再開処理に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, out)
+	reviewDates := make([]ReviewDateResponse, len(out.ReviewDates))
+	for i, rd := range out.ReviewDates {
+		reviewDates[i] = ReviewDateResponse{
+			ReviewDateID:         rd.ReviewDateID,
+			UserID:               rd.UserID,
+			CategoryID:           rd.CategoryID,
+			BoxID:                rd.BoxID,
+			ItemID:               rd.ItemID,
+			StepNumber:           rd.StepNumber,
+			InitialScheduledDate: rd.InitialScheduledDate,
+			ScheduledDate:        rd.ScheduledDate,
+			IsCompleted:          rd.IsCompleted,
+		}
+	}
+
+	res := UpdateItemAsUnFinishedForceResponse{
+		ItemID:      out.ItemID,
+		UserID:      out.UserID,
+		IsFinished:  out.IsFinished,
+		EditedAt:    out.EditedAt,
+		ReviewDates: reviewDates,
+	}
+
+	return c.JSON(http.StatusOK, res)
+
 }
 
 // 取得系
@@ -277,7 +407,8 @@ func (ic *itemController) GetAllUnFinishedItemsByBoxID(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "ボックス内の復習物取得に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, out)
+	return c.JSON(http.StatusOK, mapToItemResponse(out))
+
 }
 
 func (ic *itemController) GetAllUnFinishedUnclassifiedItemsByUserID(c echo.Context) error {
@@ -291,7 +422,8 @@ func (ic *itemController) GetAllUnFinishedUnclassifiedItemsByUserID(c echo.Conte
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "未分類の復習物取得に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, out)
+	return c.JSON(http.StatusOK, mapToItemResponse(out))
+
 }
 
 func (ic *itemController) GetAllUnFinishedUnclassifiedItemsByCategoryID(c echo.Context) error {
@@ -306,7 +438,8 @@ func (ic *itemController) GetAllUnFinishedUnclassifiedItemsByCategoryID(c echo.C
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "カテゴリ内の未分類復習物取得に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, out)
+	return c.JSON(http.StatusOK, mapToItemResponse(out))
+
 }
 
 // カウント系
@@ -321,7 +454,16 @@ func (ic *itemController) CountItemsGroupedByBoxByUserID(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "ボックス毎の復習物数取得に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, out)
+	res := make([]ItemCountGroupedByBoxResponse, len(out))
+	for i, r := range out {
+		res[i] = ItemCountGroupedByBoxResponse{
+			CategoryID: r.CategoryID,
+			BoxID:      r.BoxID,
+			Count:      r.Count,
+		}
+	}
+	return c.JSON(http.StatusOK, res)
+
 }
 
 func (ic *itemController) CountUnclassifiedItemsGroupedByCategoryByUserID(c echo.Context) error {
@@ -335,7 +477,15 @@ func (ic *itemController) CountUnclassifiedItemsGroupedByCategoryByUserID(c echo
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "カテゴリ毎の未分類復習物数取得に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, out)
+	res := make([]UnclassifiedItemCountGroupedByCategoryResponse, len(out))
+	for i, r := range out {
+		res[i] = UnclassifiedItemCountGroupedByCategoryResponse{
+			CategoryID: r.CategoryID,
+			Count:      r.Count,
+		}
+	}
+	return c.JSON(http.StatusOK, res)
+
 }
 
 func (ic *itemController) CountUnclassifiedItemsByUserID(c echo.Context) error {
@@ -349,7 +499,8 @@ func (ic *itemController) CountUnclassifiedItemsByUserID(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "未分類復習物数取得に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, echo.Map{"count": out})
+	return c.JSON(http.StatusOK, CountResponse{Count: out})
+
 }
 
 func (ic *itemController) CountDailyDatesGroupedByBoxByUserID(c echo.Context) error {
@@ -364,7 +515,16 @@ func (ic *itemController) CountDailyDatesGroupedByBoxByUserID(c echo.Context) er
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "ボックス毎の今日の復習数取得に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, out)
+	res := make([]DailyCountGroupedByBoxResponse, len(out))
+	for i, r := range out {
+		res[i] = DailyCountGroupedByBoxResponse{
+			CategoryID: r.CategoryID,
+			BoxID:      r.BoxID,
+			Count:      r.Count,
+		}
+	}
+	return c.JSON(http.StatusOK, res)
+
 }
 
 func (ic *itemController) CountDailyDatesUnclassifiedGroupedByCategoryByUserID(c echo.Context) error {
@@ -379,7 +539,15 @@ func (ic *itemController) CountDailyDatesUnclassifiedGroupedByCategoryByUserID(c
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "カテゴリ毎の今日の未分類復習数取得に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, out)
+	res := make([]UnclassifiedDailyDatesCountGroupedByCategoryResponse, len(out))
+	for i, r := range out {
+		res[i] = UnclassifiedDailyDatesCountGroupedByCategoryResponse{
+			CategoryID: r.CategoryID,
+			Count:      r.Count,
+		}
+	}
+	return c.JSON(http.StatusOK, res)
+
 }
 
 func (ic *itemController) CountDailyDatesUnclassifiedByUserID(c echo.Context) error {
@@ -394,7 +562,8 @@ func (ic *itemController) CountDailyDatesUnclassifiedByUserID(c echo.Context) er
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "今日の未分類復習数取得に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, out)
+	return c.JSON(http.StatusOK, CountResponse{Count: out})
+
 }
 
 // 今日の全復習日数を取得
@@ -411,7 +580,8 @@ func (ic *itemController) CountAllDailyReviewDates(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "今日の復習日数の取得に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, echo.Map{"count": count})
+	return c.JSON(http.StatusOK, CountResponse{Count: count})
+
 }
 
 // 今日の復習日一覧取得
@@ -428,7 +598,82 @@ func (ic *itemController) GetAllDailyReviewDates(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "復習日の取得に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, result)
+	res := GetDailyReviewDatesResponse{}
+
+	categories := make([]DailyReviewDatesGroupedByCategoryResponse, len(result.Categories))
+	for i, cat := range result.Categories {
+		boxes := make([]DailyReviewDatesGroupedByBoxResponse, len(cat.Boxes))
+		for j, box := range cat.Boxes {
+			reviewDates := make([]DailyReviewDatesByBoxResponse, len(box.ReviewDates))
+			for k, rd := range box.ReviewDates {
+				reviewDates[k] = DailyReviewDatesByBoxResponse{
+					ReviewDateID:      rd.ReviewDateID,
+					CategoryID:        rd.CategoryID,
+					BoxID:             rd.BoxID,
+					StepNumber:        rd.StepNumber,
+					PrevScheduledDate: rd.PrevScheduledDate,
+					ScheduledDate:     rd.ScheduledDate,
+					NextScheduledDate: rd.NextScheduledDate,
+					IsCompleted:       rd.IsCompleted,
+					ItemName:          rd.ItemName,
+					Detail:            rd.Detail,
+					RegisteredAt:      rd.RegisteredAt,
+					EditedAt:          rd.EditedAt,
+				}
+			}
+			boxes[j] = DailyReviewDatesGroupedByBoxResponse{
+				BoxID:        box.BoxID,
+				CategoryID:   box.CategoryID,
+				BoxName:      box.BoxName,
+				ReviewDates:  reviewDates,
+				TargetWeight: box.TargetWeight,
+			}
+		}
+
+		unclassified := make([]UnclassifiedDailyReviewDatesGroupedByCategoryResponse, len(cat.UnclassifiedDailyReviewDatesByCategory))
+		for j, rd := range cat.UnclassifiedDailyReviewDatesByCategory {
+			unclassified[j] = UnclassifiedDailyReviewDatesGroupedByCategoryResponse{
+				ReviewDateID:      rd.ReviewDateID,
+				CategoryID:        rd.CategoryID,
+				StepNumber:        rd.StepNumber,
+				PrevScheduledDate: rd.PrevScheduledDate,
+				ScheduledDate:     rd.ScheduledDate,
+				NextScheduledDate: rd.NextScheduledDate,
+				IsCompleted:       rd.IsCompleted,
+				ItemName:          rd.ItemName,
+				Detail:            rd.Detail,
+				RegisteredAt:      rd.RegisteredAt,
+				EditedAt:          rd.EditedAt,
+			}
+		}
+
+		categories[i] = DailyReviewDatesGroupedByCategoryResponse{
+			CategoryID:                             cat.CategoryID,
+			CategoryName:                           cat.CategoryName,
+			Boxes:                                  boxes,
+			UnclassifiedDailyReviewDatesByCategory: unclassified,
+		}
+	}
+	res.Categories = categories
+
+	userUnclassified := make([]UnclassifiedDailyReviewDatesGroupedByUserResponse, len(result.DailyReviewDatesGroupedByUser))
+	for i, rd := range result.DailyReviewDatesGroupedByUser {
+		userUnclassified[i] = UnclassifiedDailyReviewDatesGroupedByUserResponse{
+			ReviewDateID:      rd.ReviewDateID,
+			StepNumber:        rd.StepNumber,
+			PrevScheduledDate: rd.PrevScheduledDate,
+			ScheduledDate:     rd.ScheduledDate,
+			NextScheduledDate: rd.NextScheduledDate,
+			IsCompleted:       rd.IsCompleted,
+			ItemName:          rd.ItemName,
+			Detail:            rd.Detail,
+			RegisteredAt:      rd.RegisteredAt,
+			EditedAt:          rd.EditedAt,
+		}
+	}
+	res.DailyReviewDatesGroupedByUser = userUnclassified
+
+	return c.JSON(http.StatusOK, res)
 }
 
 func (ic *itemController) GetFinishedItemsByBoxID(c echo.Context) error {
@@ -443,7 +688,8 @@ func (ic *itemController) GetFinishedItemsByBoxID(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "ボックス内の完了した復習物取得に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, out)
+	return c.JSON(http.StatusOK, mapToItemResponse(out))
+
 }
 
 func (ic *itemController) GetUnclassfiedFinishedItemsByCategoryID(c echo.Context) error {
@@ -458,7 +704,8 @@ func (ic *itemController) GetUnclassfiedFinishedItemsByCategoryID(c echo.Context
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "カテゴリ内の未分類完了復習物取得に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, out)
+	return c.JSON(http.StatusOK, mapToItemResponse(out))
+
 }
 
 func (ic *itemController) GetUnclassfiedFinishedItemsByUserID(c echo.Context) error {
@@ -472,5 +719,6 @@ func (ic *itemController) GetUnclassfiedFinishedItemsByUserID(c echo.Context) er
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "完了した復習物取得に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, out)
+	return c.JSON(http.StatusOK, mapToItemResponse(out))
+
 }

--- a/controller/item/mapper.go
+++ b/controller/item/mapper.go
@@ -1,0 +1,38 @@
+package item
+
+import itemUsecase "github.com/minminseo/recall-setter/usecase/item"
+
+func mapToItemResponse(items []*itemUsecase.GetItemOutput) []ItemResponse {
+	res := make([]ItemResponse, len(items))
+	for i, item := range items {
+		reviewDates := make([]ReviewDateResponse, len(item.ReviewDates))
+		for j, rd := range item.ReviewDates {
+			reviewDates[j] = ReviewDateResponse{
+				ReviewDateID:         rd.ReviewDateID,
+				UserID:               rd.UserID,
+				CategoryID:           rd.CategoryID,
+				BoxID:                rd.BoxID,
+				ItemID:               rd.ItemID,
+				StepNumber:           rd.StepNumber,
+				InitialScheduledDate: rd.InitialScheduledDate,
+				ScheduledDate:        rd.ScheduledDate,
+				IsCompleted:          rd.IsCompleted,
+			}
+		}
+		res[i] = ItemResponse{
+			ItemID:       item.ItemID,
+			UserID:       item.UserID,
+			CategoryID:   item.CategoryID,
+			BoxID:        item.BoxID,
+			PatternID:    item.PatternID,
+			Name:         item.Name,
+			Detail:       item.Detail,
+			LearnedDate:  item.LearnedDate,
+			IsFinished:   item.IsFinished,
+			RegisteredAt: item.RegisteredAt,
+			EditedAt:     item.EditedAt,
+			ReviewDates:  reviewDates,
+		}
+	}
+	return res
+}

--- a/controller/item/response.go
+++ b/controller/item/response.go
@@ -1,0 +1,157 @@
+package item
+
+import "time"
+
+type ReviewDateResponse struct {
+	ReviewDateID         string  `json:"review_date_id"`
+	UserID               string  `json:"user_id"`
+	CategoryID           *string `json:"category_id"`
+	BoxID                *string `json:"box_id"`
+	ItemID               string  `json:"item_id"`
+	StepNumber           int     `json:"step_number"`
+	InitialScheduledDate string  `json:"initial_scheduled_date"`
+	ScheduledDate        string  `json:"scheduled_date"`
+	IsCompleted          bool    `json:"is_completed"`
+}
+
+type ItemResponse struct {
+	ItemID       string               `json:"item_id"`
+	UserID       string               `json:"user_id"`
+	CategoryID   *string              `json:"category_id"`
+	BoxID        *string              `json:"box_id"`
+	PatternID    *string              `json:"pattern_id"`
+	Name         string               `json:"name"`
+	Detail       string               `json:"detail"`
+	LearnedDate  string               `json:"learned_date"`
+	IsFinished   bool                 `json:"is_finished"`
+	RegisteredAt time.Time            `json:"registered_at"`
+	EditedAt     time.Time            `json:"edited_at"`
+	ReviewDates  []ReviewDateResponse `json:"review_dates"`
+}
+
+type UpdateItemAsFinishedForceResponse struct {
+	ItemID     string    `json:"item_id"`
+	UserID     string    `json:"user_id"`
+	IsFinished bool      `json:"is_finished"`
+	EditedAt   time.Time `json:"edited_at"`
+}
+
+type UpdateReviewDateAsCompletedResponse struct {
+	ReviewDateID string    `json:"review_date_id"`
+	UserID       string    `json:"user_id"`
+	IsCompleted  bool      `json:"is_completed"`
+	IsFinished   bool      `json:"is_finished"`
+	EditedAt     time.Time `json:"edited_at"`
+}
+
+type UpdateReviewDateAsInCompletedResponse struct {
+	ReviewDateID string    `json:"review_date_id"`
+	UserID       string    `json:"user_id"`
+	IsCompleted  bool      `json:"is_completed"`
+	IsFinished   bool      `json:"is_finished"`
+	EditedAt     time.Time `json:"edited_at"`
+}
+
+type UpdateBackReviewDateResponse struct {
+	ItemID      string               `json:"item_id"`
+	UserID      string               `json:"user_id"`
+	IsFinished  bool                 `json:"is_finished"`
+	EditedAt    time.Time            `json:"edited_at"`
+	ReviewDates []ReviewDateResponse `json:"review_dates"`
+}
+
+type UpdateItemAsUnFinishedForceResponse struct {
+	ItemID      string               `json:"item_id"`
+	UserID      string               `json:"user_id"`
+	IsFinished  bool                 `json:"is_finished"`
+	EditedAt    time.Time            `json:"edited_at"`
+	ReviewDates []ReviewDateResponse `json:"review_dates"`
+}
+
+type CountResponse struct {
+	Count int `json:"count"`
+}
+
+type ItemCountGroupedByBoxResponse struct {
+	CategoryID string `json:"category_id"`
+	BoxID      string `json:"box_id"`
+	Count      int    `json:"count"`
+}
+
+type UnclassifiedItemCountGroupedByCategoryResponse struct {
+	CategoryID string `json:"category_id"`
+	Count      int    `json:"count"`
+}
+
+type DailyCountGroupedByBoxResponse struct {
+	CategoryID string `json:"category_id"`
+	BoxID      string `json:"box_id"`
+	Count      int    `json:"count"`
+}
+
+type UnclassifiedDailyDatesCountGroupedByCategoryResponse struct {
+	CategoryID string `json:"category_id"`
+	Count      int    `json:"count"`
+}
+
+type DailyReviewDatesByBoxResponse struct {
+	ReviewDateID      string    `json:"review_date_id"`
+	CategoryID        string    `json:"category_id"`
+	BoxID             string    `json:"box_id"`
+	StepNumber        int       `json:"step_number"`
+	PrevScheduledDate *string   `json:"prev_scheduled_date"`
+	ScheduledDate     string    `json:"scheduled_date"`
+	NextScheduledDate *string   `json:"next_scheduled_date"`
+	IsCompleted       bool      `json:"is_completed"`
+	ItemName          string    `json:"item_name"`
+	Detail            string    `json:"detail"`
+	RegisteredAt      time.Time `json:"registered_at"`
+	EditedAt          time.Time `json:"edited_at"`
+}
+
+type DailyReviewDatesGroupedByBoxResponse struct {
+	BoxID        string                          `json:"box_id"`
+	CategoryID   string                          `json:"category_id"`
+	BoxName      string                          `json:"box_name"`
+	ReviewDates  []DailyReviewDatesByBoxResponse `json:"review_dates"`
+	TargetWeight string                          `json:"target_weight"`
+}
+
+type UnclassifiedDailyReviewDatesGroupedByCategoryResponse struct {
+	ReviewDateID      string    `json:"review_date_id"`
+	CategoryID        string    `json:"category_id"`
+	StepNumber        int       `json:"step_number"`
+	PrevScheduledDate *string   `json:"prev_scheduled_date"`
+	ScheduledDate     string    `json:"scheduled_date"`
+	NextScheduledDate *string   `json:"next_scheduled_date"`
+	IsCompleted       bool      `json:"is_completed"`
+	ItemName          string    `json:"item_name"`
+	Detail            string    `json:"detail"`
+	RegisteredAt      time.Time `json:"registered_at"`
+	EditedAt          time.Time `json:"edited_at"`
+}
+
+type DailyReviewDatesGroupedByCategoryResponse struct {
+	CategoryID                             string                                                  `json:"category_id"`
+	CategoryName                           string                                                  `json:"category_name"`
+	Boxes                                  []DailyReviewDatesGroupedByBoxResponse                  `json:"boxes"`
+	UnclassifiedDailyReviewDatesByCategory []UnclassifiedDailyReviewDatesGroupedByCategoryResponse `json:"unclassified_daily_review_dates_by_category"`
+}
+
+type UnclassifiedDailyReviewDatesGroupedByUserResponse struct {
+	ReviewDateID      string    `json:"review_date_id"`
+	StepNumber        int       `json:"step_number"`
+	PrevScheduledDate *string   `json:"prev_scheduled_date"`
+	ScheduledDate     string    `json:"scheduled_date"`
+	NextScheduledDate *string   `json:"next_scheduled_date"`
+	IsCompleted       bool      `json:"is_completed"`
+	ItemName          string    `json:"item_name"`
+	Detail            string    `json:"detail"`
+	RegisteredAt      time.Time `json:"registered_at"`
+	EditedAt          time.Time `json:"edited_at"`
+}
+
+type GetDailyReviewDatesResponse struct {
+	Categories                    []DailyReviewDatesGroupedByCategoryResponse         `json:"categories"`
+	DailyReviewDatesGroupedByUser []UnclassifiedDailyReviewDatesGroupedByUserResponse `json:"daily_review_dates_grouped_by_user"`
+}

--- a/controller/pattern/pattern_controller.go
+++ b/controller/pattern/pattern_controller.go
@@ -54,7 +54,28 @@ func (pc *patternController) CreatePattern(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "パターンの作成に失敗しました: " + err.Error()})
 	}
 
-	return c.JSON(http.StatusCreated, out)
+	resSteps := make([]PatternStepResponse, len(out.Steps))
+	for i, s := range out.Steps {
+		resSteps[i] = PatternStepResponse{
+			PatternStepID: s.PatternStepID,
+			UserID:        s.UserID,
+			PatternID:     s.PatternID,
+			StepNumber:    s.StepNumber,
+			IntervalDays:  s.IntervalDays,
+		}
+	}
+
+	res := PatternResponse{
+		ID:           out.ID,
+		UserID:       out.UserID,
+		Name:         out.Name,
+		TargetWeight: out.TargetWeight,
+		RegisteredAt: out.RegisteredAt,
+		EditedAt:     out.EditedAt,
+		Steps:        resSteps,
+	}
+
+	return c.JSON(http.StatusCreated, res)
 }
 
 func (pc *patternController) GetPatterns(c echo.Context) error {
@@ -75,7 +96,31 @@ func (pc *patternController) GetPatterns(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "パターンの取得に失敗しました: " + err.Error()})
 	}
-	return c.JSON(http.StatusOK, results)
+
+	var res []PatternResponse
+	for _, p := range results {
+		steps := make([]PatternStepResponse, len(p.Steps))
+		for i, s := range p.Steps {
+			steps[i] = PatternStepResponse{
+				PatternStepID: s.PatternStepID,
+				UserID:        userID,
+				PatternID:     s.PatternID,
+				StepNumber:    s.StepNumber,
+				IntervalDays:  s.IntervalDays,
+			}
+		}
+		res = append(res, PatternResponse{
+			ID:           p.PatternID,
+			UserID:       p.UserID,
+			Name:         p.Name,
+			TargetWeight: p.TargetWeight,
+			RegisteredAt: p.RegisteredAt,
+			EditedAt:     p.EditedAt,
+			Steps:        steps,
+		})
+	}
+
+	return c.JSON(http.StatusOK, res)
 }
 
 func (pc *patternController) UpdatePattern(c echo.Context) error {
@@ -124,7 +169,28 @@ func (pc *patternController) UpdatePattern(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "パターンの更新に失敗しました: " + err.Error()})
 	}
 
-	return c.JSON(http.StatusOK, out)
+	resSteps := make([]PatternStepResponse, len(out.Steps))
+	for i, s := range out.Steps {
+		resSteps[i] = PatternStepResponse{
+			PatternStepID: s.PatternStepID,
+			UserID:        s.UserID,
+			PatternID:     s.PatternID,
+			StepNumber:    s.StepNumber,
+			IntervalDays:  s.IntervalDays,
+		}
+	}
+
+	res := PatternResponse{
+		ID:           out.PatternID,
+		UserID:       out.UserID,
+		Name:         out.Name,
+		TargetWeight: out.TargetWeight,
+		RegisteredAt: out.RegisteredAt,
+		EditedAt:     out.EditedAt,
+		Steps:        resSteps,
+	}
+
+	return c.JSON(http.StatusOK, res)
 }
 
 func (pc *patternController) DeletePattern(c echo.Context) error {

--- a/controller/pattern/response.go
+++ b/controller/pattern/response.go
@@ -1,0 +1,21 @@
+package pattern
+
+import "time"
+
+type PatternStepResponse struct {
+	PatternStepID string `json:"pattern_step_id"`
+	UserID        string `json:"user_id"`
+	PatternID     string `json:"pattern_id"`
+	StepNumber    int    `json:"step_number"`
+	IntervalDays  int    `json:"interval_days"`
+}
+
+type PatternResponse struct {
+	ID           string                `json:"id"`
+	UserID       string                `json:"user_id"`
+	Name         string                `json:"name"`
+	TargetWeight string                `json:"target_weight"`
+	RegisteredAt time.Time             `json:"registered_at"`
+	EditedAt     time.Time             `json:"edited_at"`
+	Steps        []PatternStepResponse `json:"steps"`
+}

--- a/controller/user/response.go
+++ b/controller/user/response.go
@@ -1,0 +1,34 @@
+package user
+
+type SignUpResponse struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+}
+
+type LoginResponse struct {
+	ThemeColor string `json:"theme_color"`
+	Language   string `json:"language"`
+}
+
+type VerifyEmailResponse struct {
+	ThemeColor string `json:"theme_color"`
+	Language   string `json:"language"`
+}
+
+type CsrfTokenResponse struct {
+	CsrfToken string `json:"csrf_token"`
+}
+
+type GetUserSettingResponse struct {
+	Email      string `json:"email"`
+	Timezone   string `json:"timezone"`
+	ThemeColor string `json:"theme_color"`
+	Language   string `json:"language"`
+}
+
+type UpdateUserSettingResponse struct {
+	Email      string `json:"email"`
+	Timezone   string `json:"timezone"`
+	ThemeColor string `json:"theme_color"`
+	Language   string `json:"language"`
+}

--- a/controller/user/user_controller.go
+++ b/controller/user/user_controller.go
@@ -37,7 +37,13 @@ func (uc *userController) SignUp(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, err.Error())
 	}
-	return c.JSON(http.StatusCreated, userRes)
+
+	res := SignUpResponse{
+		ID:    userRes.ID,
+		Email: userRes.Email,
+	}
+	return c.JSON(http.StatusCreated, res)
+
 }
 
 func (uc *userController) VerifyEmail(c echo.Context) error {
@@ -70,10 +76,12 @@ func (uc *userController) VerifyEmail(c echo.Context) error {
 	cookie.SameSite = http.SameSiteNoneMode
 	c.SetCookie(cookie)
 
-	return c.JSON(http.StatusOK, echo.Map{
-		"theme_color": loginRes.ThemeColor,
-		"language":    loginRes.Language,
-	})
+	res := VerifyEmailResponse{
+		ThemeColor: loginRes.ThemeColor,
+		Language:   loginRes.Language,
+	}
+	return c.JSON(http.StatusOK, res)
+
 }
 
 func (uc *userController) LogIn(c echo.Context) error {
@@ -103,10 +111,13 @@ func (uc *userController) LogIn(c echo.Context) error {
 	cookie.HttpOnly = true
 	cookie.SameSite = http.SameSiteNoneMode
 	c.SetCookie(cookie)
-	return c.JSON(http.StatusOK, echo.Map{
-		"theme_color": userRes.ThemeColor,
-		"language":    userRes.Language,
-	})
+
+	res := LoginResponse{
+		ThemeColor: userRes.ThemeColor,
+		Language:   userRes.Language,
+	}
+	return c.JSON(http.StatusOK, res)
+
 }
 
 func (uc *userController) LogOut(c echo.Context) error {
@@ -124,11 +135,12 @@ func (uc *userController) LogOut(c echo.Context) error {
 }
 
 func (uc *userController) CsrfToken(c echo.Context) error {
-	token := c.Get("csrf").(string)        // echoのコンテキストの中で、"csrf"というキーワードでtokenを取得
-	return c.JSON(http.StatusOK, echo.Map{ /*上でstring型に型アサーションしてから
-		JSONでクライアントにcsrfトークンをレスポンスする*/
-		"csrf_token": token,
-	})
+	token := c.Get("csrf").(string) // echoのコンテキストの中で、"csrf"というキーワードでtokenを取得
+	res := CsrfTokenResponse{
+		CsrfToken: token,
+	}
+	return c.JSON(http.StatusOK, res)
+
 }
 
 func (uc *userController) GetUserSetting(c echo.Context) error {
@@ -144,7 +156,14 @@ func (uc *userController) GetUserSetting(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, err.Error())
 	}
-	return c.JSON(http.StatusOK, userRes)
+
+	res := GetUserSettingResponse{
+		Email:      userRes.Email,
+		Timezone:   userRes.Timezone,
+		ThemeColor: userRes.ThemeColor,
+		Language:   userRes.Language,
+	}
+	return c.JSON(http.StatusOK, res)
 }
 
 func (uc *userController) UpdateSetting(c echo.Context) error {
@@ -177,7 +196,15 @@ func (uc *userController) UpdateSetting(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, err.Error())
 	}
-	return c.JSON(http.StatusOK, userRes)
+
+	res := UpdateUserSettingResponse{
+		Email:      userRes.Email,
+		Timezone:   userRes.Timezone,
+		ThemeColor: userRes.ThemeColor,
+		Language:   userRes.Language,
+	}
+	return c.JSON(http.StatusOK, res)
+
 }
 
 func (uc *userController) UpdatePassword(c echo.Context) error {


### PR DESCRIPTION
DONE:
- jsonタグ付きのレスポンス構造体を各パッケージごとにresponse.goに定義
- 定義したレスポンス構造体を使ってJSONオブジェクトとしてレスポンスするように修正
- itemパッケージの復習物+復習日形式のデータはマッパーとして切り出し使い回すようにした。