### PR TITLE
fix: UpdatePattenメソッドでValidateStepsを通すように修正

### DIFF
--- a/usecase/pattern/pattern_usecase.go
+++ b/usecase/pattern/pattern_usecase.go
@@ -207,6 +207,11 @@ func (pu *patternUsecase) UpdatePattern(ctx context.Context, input UpdatePattern
 		}
 	}
 
+	err = patternDomain.ValidateSteps(newSteps)
+	if err != nil {
+		return nil, err
+	}
+
 	// patternとstepは別テーブルなので同一トランザクションで永続化
 	err = pu.transactionManeger.RunInTransaction(ctx, func(ctx context.Context) error {
 		// パターンに変更がある場合、パターンを更新


### PR DESCRIPTION
DONE:
- UpdatePattenでValidateStepsを通さずに復習パターンの編集ができてしまっていたため（1, 2, 5, 4とかのステップに変更可能になっていたため）、ValidateStepsを通すように修正。