### PR TITLE
fix: category_idをWHRE句から除外

### DIFF
--- a/infrastructure/db/dbgen/box.sql.go
+++ b/infrastructure/db/dbgen/box.sql.go
@@ -232,17 +232,14 @@ SET
 WHERE
     id = $3
 AND
-    category_id = $4
-AND
-    user_id = $5
+    user_id = $4
 `
 
 type UpdateBoxParams struct {
-	Name       string             `json:"name"`
-	EditedAt   pgtype.Timestamptz `json:"edited_at"`
-	ID         pgtype.UUID        `json:"id"`
-	CategoryID pgtype.UUID        `json:"category_id"`
-	UserID     pgtype.UUID        `json:"user_id"`
+	Name     string             `json:"name"`
+	EditedAt pgtype.Timestamptz `json:"edited_at"`
+	ID       pgtype.UUID        `json:"id"`
+	UserID   pgtype.UUID        `json:"user_id"`
 }
 
 func (q *Queries) UpdateBox(ctx context.Context, arg UpdateBoxParams) error {
@@ -250,7 +247,6 @@ func (q *Queries) UpdateBox(ctx context.Context, arg UpdateBoxParams) error {
 		arg.Name,
 		arg.EditedAt,
 		arg.ID,
-		arg.CategoryID,
 		arg.UserID,
 	)
 	return err

--- a/infrastructure/db/query/box.sql
+++ b/infrastructure/db/query/box.sql
@@ -63,8 +63,6 @@ SET
 WHERE
     id = sqlc.arg(id)
 AND
-    category_id = sqlc.arg(category_id)
-AND
     user_id = sqlc.arg(user_id);
 
 -- name: UpdateBoxIfNoReviewItems :execrows


### PR DESCRIPTION
DONE:
- UpdateBoxクエリで常にnullのcategory_idをWHERE句に渡していたことによって一致するレコードが見つからないもののUpdateBoxクエリが正常に行われたことになっていたため、UpdateBoxクエリのWHERE句からcategory_idを除外。

TODO:
- 永続化前のデータをレスポンスする手法は本物のデータが更新されていなくとも一時的に更新後のデータをかえすのでこんな感じPRの不具合の例が他にもあるかもだから探す。