### PR TITLE
fix: GetAllUnFinishedUnclassifiedItemsByCategoryIDの引数の順序ミス

### DIFF
--- a/usecase/item/item_usecase.go
+++ b/usecase/item/item_usecase.go
@@ -1027,7 +1027,7 @@ func (iu *ItemUsecase) GetAllUnFinishedUnclassifiedItemsByUserID(ctx context.Con
 }
 
 func (iu *ItemUsecase) GetAllUnFinishedUnclassifiedItemsByCategoryID(ctx context.Context, userID string, categoryID string) ([]*GetItemOutput, error) {
-	items, err := iu.itemRepo.GetAllUnFinishedUnclassifiedItemsByCategoryID(ctx, userID, categoryID)
+	items, err := iu.itemRepo.GetAllUnFinishedUnclassifiedItemsByCategoryID(ctx, categoryID, userID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
DONE:
- リポジトリインターフェースが持つGetAllUnFinishedUnclassifiedItemsByCategoryIDメソッドに渡す引数の順序が間違っていたため、修正。
  - 背景：
    - クライアントで正常に取得できていなかった。

TODO:
- テストコードで一度全てテスト