### PR TITLE
fix: GetUnclassfiedFinishedItemsByCategoryIDの引数の順序ミスを修正

### DIFF
--- a/domain/item/item_repository.go
+++ b/domain/item/item_repository.go
@@ -137,7 +137,7 @@ type IItemRepository interface {
 
 	// 完了済み復習物系を取得する系
 	GetFinishedItemsByBoxID(ctx context.Context, boxID string, userID string) ([]*Item, error)
-	GetUnclassfiedFinishedItemsByCategoryID(ctx context.Context, userID string, categoryID string) ([]*Item, error)
+	GetUnclassfiedFinishedItemsByCategoryID(ctx context.Context, categoryID string, userID string) ([]*Item, error)
 	GetUnclassfiedFinishedItemsByUserID(ctx context.Context, userID string) ([]*Item, error)
 
 	/*--------------------*/

--- a/usecase/item/item_usecase.go
+++ b/usecase/item/item_usecase.go
@@ -1489,7 +1489,7 @@ func (iu *ItemUsecase) GetFinishedItemsByBoxID(ctx context.Context, boxID string
 }
 
 func (iu *ItemUsecase) GetUnclassfiedFinishedItemsByCategoryID(ctx context.Context, userID string, categoryID string) ([]*GetItemOutput, error) {
-	items, err := iu.itemRepo.GetUnclassfiedFinishedItemsByCategoryID(ctx, userID, categoryID)
+	items, err := iu.itemRepo.GetUnclassfiedFinishedItemsByCategoryID(ctx, categoryID, userID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
DONE:
- GetUnclassfiedFinishedItemsByCategoryIDの引数の順序ミスを修正
  - 背景:
      - クライアントでカテゴリータブでカテゴリー選択かつボックスタブで未分類選択時の復習物一覧画面で完了済み復習物モーダルに該当復習物が表示されなかった。