### PR TITLE
fix: in.PatternID == nil時に正常にCreateItemメソッドを終了するように修正

### DIFF
--- a/usecase/item/item_usecase.go
+++ b/usecase/item/item_usecase.go
@@ -70,6 +70,20 @@ func (iu *ItemUsecase) CreateItem(ctx context.Context, in CreateItemInput) (*Cre
 		if err != nil {
 			return nil, err
 		}
+		out := &CreateItemOutput{
+			ItemID:       newItem.ItemID,
+			UserID:       newItem.UserID,
+			CategoryID:   newItem.CategoryID,
+			BoxID:        newItem.BoxID,
+			PatternID:    newItem.PatternID,
+			Name:         newItem.Name,
+			Detail:       newItem.Detail,
+			LearnedDate:  newItem.LearnedDate.Format("2006-01-02"),
+			IsCompleted:  newItem.IsFinished,
+			RegisteredAt: newItem.RegisteredAt,
+			EditedAt:     newItem.EditedAt,
+		}
+		return out, nil
 	}
 
 	var newReviewdates []*ItemDomain.Reviewdate


### PR DESCRIPTION
DONE:
- 対応:
  - if in.PatternID == nilで、itemRepo.CreateItemを実行した後に、CreateItemOutputを生成し、returnで即座に関数を終了させるように修正。
- 背景:
  - category_idがNULL、box_idがNULL、pattern_idがNULLの状態でreview_itemsの作成リクエスト（CreateItemメソッド）を実行した時、if in.PatternID == nilの分岐を通ったあと、returnされずに後続の処理の処理が続いてしまっていたことにより、再度itemRepo.CreateItemを実行することによるUUID重複エラーが返っていた。