### PR TITLE
fix: isPatternNilToNotNil時にrequstedSelectedPatternStepsを正常に生成するように修正

### DIFF
--- a/usecase/item/item_usecase.go
+++ b/usecase/item/item_usecase.go
@@ -235,8 +235,17 @@ func (iu *ItemUsecase) UpdateItem(ctx context.Context, input UpdateItemInput) (*
 		isSamePatternID = true
 	}
 
-	var currentSelectedPatternSteps []*PatternDomain.PatternStep
 	var requstedSelectedPatternSteps []*PatternDomain.PatternStep
+	// NULL → NOT NULLの場合はINSERTクエリ確定でパターンの比較が不要なのでrequstedSelectedPatternStepsだけ取得
+	if isPatternNilToNotNil {
+		requstedSelectedPatternSteps, err = iu.patternRepo.GetAllPatternStepsByPatternID(ctx, *input.PatternID, input.UserID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// NOT NULL →　NOT NULLの場合はINSERTクエリかUPDATEクエリで済むか判別するためのフラグを作成する必要があるのでrequstedSelectedPatternStepsとcurrentSelectedPatternSteps両方取得
+	var currentSelectedPatternSteps []*PatternDomain.PatternStep
 	isPatternStepsLengthDiff := false
 	isOnlyPatternStepsIntervalDaysDiff := false
 	isSamePatternStepsStructure := false


### PR DESCRIPTION
### 状況
`FormatWithOverdueMarkedCompleted`メソッドに空の`requstedSelectedPatternSteps`（→`targetPatternSteps`）を渡していて、
```go
result[len(targetPatternSteps)-1].ScheduledDate
```
で`index out of range`エラーが起きている。
`FormatWithOverdueMarkedCompleted`の実行条件（`isPatternNilToNotNil || isPatternStepsLengthDiff`）は満たしてたけど、`requstedSelectedPatternSteps`の生成が`isPatternNotNilToNotNil`でしか行われておらず、`isPatternNilToNotNil`で行われていなかった。

### 原因
下記3つのフラグの作成に意識がいってしまい`requstedSelectedPatternSteps`の作成条件を整理できていなかった。
```go
isPatternStepsLengthDiff := false
isOnlyPatternStepsIntervalDaysDiff := false
isSamePatternStepsStructure := false
```

### 対応
`isPatternNilToNotNil`時に、`requstedSelectedPatternSteps` を生成する処理を追加する。

### 対応（具体）
~~`requstedSelectedPatternSteps`作成条件に`isPatternNilToNotNil`を論理和で追加して`requstedSelectedPatternSteps`を作成し、正常に`FormatWithOverdueMarkedCompleted`が実行されるようにする。~~
→if文のネストが深くなるからやめた（方法1で後述）

方法1（ボツ）
既存の`if isPatternNotNilToNotNil`に
```go
if isPatternNotNilToNotNil || isPatternNilToNotNil {

```
のように論理和で追加しようとしたけど、内部で`!isPatternNilToNotNil`のネストが一個深くなるからやめた。

方法2（ボツ）
```go
if isPatternNotNilToNotNil || isPatternNilToNotNil {
    // requstedSelectedPatternSteps生成処理
}

if isPatternNotNilToNotNil {
    // currentSelectedPatternStepsも生成してisPatternNotNilToNotNil用の処理をする
}
```
上記の方法みたいに先にisPatternNilToNotNilの条件と同時に`requstedSelectedPatternSteps`を生成するのも`isPatternNilToNotNil`と`isPatternNotNilToNotNil`の意図が混在してる感じがしたからなし。


方法3（採用）
`isPatternNilToNotNil`と`isPatternNotNilToNotNil`のif文に分けて、`if isPatternNilToNotNil`で`requstedSelectedPatternSteps` を生成する処理を追加。
`requstedSelectedPatternSteps`の生成コードは冗長になるけど、`isPatternNilToNotNil`の時と、`isPatternNotNilToNotNil`のときの違いで意図が明確になる。
