### PR TITLE
fix: pattern_idの比較で間接参照して比較するように修正

### DIFF
--- a/usecase/item/item_usecase.go
+++ b/usecase/item/item_usecase.go
@@ -231,7 +231,7 @@ func (iu *ItemUsecase) UpdateItem(ctx context.Context, input UpdateItemInput) (*
 	// pettern_idが一致するか（nullとnullの場合もtrueとなるのでisPatternNotNilToNotNilと必ず併用）
 	// 1, 2, 3
 	isSamePatternID := false
-	if currentItem.PatternID == input.PatternID {
+	if *currentItem.PatternID == *input.PatternID {
 		isSamePatternID = true
 	}
 


### PR DESCRIPTION
### 根本の原因
pattern_idの比較は
```go
isSamePatternID := false
if currentItem.PatternID == input.PatternID {
		isSamePatternID = true
}
```
こうなってて、`currentItem.PatternID`と`input.PatternID`はポインタ型なので、これだとポインタの参照先の値ではなく、アドレスの比較になってしまう。この2つの変数は別々のアドレスなので、同じpattern_idを比較していたつもりでも必ず`isSamePatternID`が`false`になるのが根本の原因。

### 状況
`usecase/item/item_usecase.go`のUpdateItem`でpattern_id`が一致しているはずでも必ず`ItemDomain.ErrHasCompletedReviewDate`のエラーが返ってしまう。これは297行目の分岐の
```go
if (isPatternNotNilToNotNil && !isLearnedDateChanged && !isSamePatternID)
```
 この条件を通っていることによってエラーが発生していて、この中の`!isSamePatternID`が不正にtrueになっているのが原因。
そもそもこの297行目の分岐はクライアント側の不正なリクエスト（`is_completed`が`false`な`review_dates`を持つ`review_items`は`pattern_id`の変更が不可という制約の違反）をサーバー側で保険的に防御するためのもので、この条件を通る時、`hasCompleted`は必ず`false`であるべきだけど、これが`true`になるような`review_items`に対して`(isPatternNotNilToNotNil && !isLearnedDateChanged && !isSamePatternID)`がtrueなリクエストが発生してしまっている。

`!isSamePatternID`のフラグは、234行目の`if currentItem.PatternID == input.PatternID`で生成していて、この比較に使われている2つの変数はポインタ型なので、これだとアドレスの比較になり必ず`isSamePatternID`がfalseになるようになっていた。


### 原因
型の確認不足

### 対応

```go
isSamePatternID := false
	if currentItem.PatternID == input.PatternID {
		isSamePatternID = true
}
```
ここで比較するときは間接参照して比較する。