### PR TITLE
Fix/#121/updateitem review dates box

### DIFF
--- a/domain/item/item.go
+++ b/domain/item/item.go
@@ -208,3 +208,12 @@ func (s *Reviewdate) Validate() error {
 		),
 	)
 }
+
+func (s *Reviewdate) SetOnlyIDs(
+	categoryID *string,
+	boxID *string,
+) error {
+	s.CategoryID = categoryID
+	s.BoxID = boxID
+	return nil
+}

--- a/infrastructure/db/dbgen/item.sql.go
+++ b/infrastructure/db/dbgen/item.sql.go
@@ -7,7 +7,6 @@ package dbgen
 
 import (
 	"context"
-
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -1567,12 +1566,14 @@ func (q *Queries) UpdateReviewDateAsInCompleted(ctx context.Context, arg UpdateR
 const updateReviewDates = `-- name: UpdateReviewDates :exec
 UPDATE review_dates r
 SET
+    category_id = v.category_id,
+    box_id = v.box_id,
     scheduled_date = v.scheduled_date,
     is_completed = v.is_completed
 FROM
     UNNEST(
         $2::reviewdate_input[]
-    ) AS v(id, scheduled_date, is_completed)
+    ) AS v(id, category_id, box_id, scheduled_date, is_completed)
 WHERE
     r.id = v.id
 AND

--- a/infrastructure/db/query/item.sql
+++ b/infrastructure/db/query/item.sql
@@ -123,12 +123,14 @@ AND
 -- name: UpdateReviewDates :exec
 UPDATE review_dates r
 SET
+    category_id = v.category_id,
+    box_id = v.box_id,
     scheduled_date = v.scheduled_date,
     is_completed = v.is_completed
 FROM
     UNNEST(
         sqlc.arg(input)::reviewdate_input[]
-    ) AS v(id, scheduled_date, is_completed)
+    ) AS v(id, category_id, box_id, scheduled_date, is_completed)
 WHERE
     r.id = v.id
 AND

--- a/infrastructure/repository/item_repository.go
+++ b/infrastructure/repository/item_repository.go
@@ -270,8 +270,7 @@ func (r *itemRepository) UpdateReviewDates(ctx context.Context, reviewdates []*i
 
 	inputs := make([]string, len(reviewdates))
 	for i, rd := range reviewdates {
-		// UNNESTに渡すための(id,scheduled_date,is_completed)形式の文字列を生成
-		// CategoryID, BoxIDがnilの場合はNULLを入れる
+		// UNNESTに渡すための(id,category_id,box_id,scheduled_date,is_completed)形式の文字列を生成
 		var categoryID string
 		if rd.CategoryID != nil {
 			categoryID = *rd.CategoryID

--- a/infrastructure/repository/item_repository.go
+++ b/infrastructure/repository/item_repository.go
@@ -271,7 +271,16 @@ func (r *itemRepository) UpdateReviewDates(ctx context.Context, reviewdates []*i
 	inputs := make([]string, len(reviewdates))
 	for i, rd := range reviewdates {
 		// UNNESTに渡すための(id,scheduled_date,is_completed)形式の文字列を生成
-		inputs[i] = fmt.Sprintf(`(%q, %q, %t)`, rd.ReviewdateID, rd.ScheduledDate.Format("2006-01-02"), rd.IsCompleted)
+		// CategoryID, BoxIDがnilの場合はNULLを入れる
+		var categoryID string
+		if rd.CategoryID != nil {
+			categoryID = *rd.CategoryID
+		}
+		var boxID string
+		if rd.BoxID != nil {
+			boxID = *rd.BoxID
+		}
+		inputs[i] = fmt.Sprintf("(%s,%s,%s,%s,%t)", rd.ReviewdateID, categoryID, boxID, rd.ScheduledDate.Format("2006-01-02"), rd.IsCompleted)
 	}
 
 	params := dbgen.UpdateReviewDatesParams{

--- a/migrations/000009_create_musics_table.up.sql
+++ b/migrations/000009_create_musics_table.up.sql
@@ -1,5 +1,7 @@
 CREATE TYPE reviewdate_input AS (
     id uuid,
+    category_id uuid,
+    box_id uuid,
     scheduled_date date,
     is_completed boolean
 );


### PR DESCRIPTION
## 概要
review_datesのscheduled_dateに変化の伴わないcategory_idとbox_idの更新条件の時用の処理を追加し、この条件のリクエストをしてもreview_datesのcategory_idとbox_idが更新されない不具合を修正。

## 変更内容
**infrastructure/db/query/item.sql**
1.  UPDATEのSET句にcategory_idとbox_idを追加し、UNNEST式の列定義にcategory_idとbox_idを追加することでこの２カラムもされるように修正

**domain/item/item.go**
1. `Reviewdate`の`CategoryID`と`BoxID`を更新するためのメソッドを定義

**infrastructure/repository/item_repository.go**
1. `UNNEST`に渡す用の`inputs[i]`に`categoryID`, `boxID`を追加。
2. rd.CategoryIDとrd.BoxIDはポインタ型なので、`target != nil`のときに簡潔参照で値を取得して、`inputs[i]`で`nil`と`非nil`両方扱えるようにした。既存の`%q`を使うと値がダブルクォートで囲まれるので、値がゼロ値の時に`""`がUPDATE句に渡されてしまうためSQLで'UUID'キャスト時にエラーになるので、`%s`を使ってNULLを渡せるようにした。

**migrations/000009_create_musics_table.up.sql**
1. `UNNEST`式で使う`reviewdate_input`で`category_id`と`box_id`を扱えるように修正

**usecase/item/item_usecase.go**
1. review_datesのcategory_idとbox_idだけの更新を行うためにnewReviewdatesを生成する処理を追加
2. `box_id`と`category_id`でも`nil`と`非nil`の変化を判定するフラグ群を定義し、

    ```go
    if (isSamePatternStepsStructure || isSamePatternID) && 
        (!isLearnedDateChanged) &&
        (isCategoryNilToNotNil || 
        isCategoryNotNilToNil || 
        !isSameCategoryID || 
        isBoxNilToNotNil || 
        isBoxNotNilToNil || 
        !isSameBoxID) {
            // newReviewdatesの生成処理
        }
    ```
    この条件式のように「学習日（`learned_date`）が同じで、復習日の再生成も必要内ときに、このフラグ群の結果の中で一つでも変化を伴うものがある時」に、`box_id`と`category_id`だけが更新された`newReviewdates`を生成するようにした。この時の条件と永続化時の条件は同じある必要があるので、`newReviewdates`の生成と同時に、新しく定義した`isOnlyCategoryIDBoxIDUpdate`を`true`にし、このフラグが`true`の時に`itemRepo.UpdateReviewDates`が実行されるようにした。
4. `isOnlyCategoryIDBoxIDUpdate`の時にも`itemRepo.UpdateReviewDate`を呼び出すように修正