### PR TITLE
fix: 対応言語としてenを追加

### DIFF
--- a/domain/user/user.go
+++ b/domain/user/user.go
@@ -123,7 +123,7 @@ const (
 
 	// 言語
 	LanguageJa string = "ja"
-	// LanguageEn languageName = "en"
+	LanguageEn string = "en"
 )
 
 var allowedTimeZones = map[string]struct{}{


### PR DESCRIPTION
## 概要
対応言語としてenを追加

## 変更内容
- `// LanguageEn languageName = "en"`のコメントアウトを解除し、データ型を`string`に変更