### PR TITLE
bug: LanguageEnのコメントアウトを解除

### DIFF
--- a/domain/user/user.go
+++ b/domain/user/user.go
@@ -136,7 +136,7 @@ var allowedThemeColors = map[string]struct{}{
 }
 var allowedLanguages = map[string]struct{}{
 	LanguageJa: {},
-	// LanguageEn: {},
+	LanguageEn: {},
 }
 
 // パスワードハッシュ化


### PR DESCRIPTION
## 概要
対応言語"en"有効化でLanguageEn型を有効化しておらず、`allowedLanguages`の存在チェックでエラーになる不具合を修正。

## 変更内容
1. LanguageEnのコメントアウトを解除

## 関連
Relates to #123 