### PR TITLE
Bug/#134/update initial scheduled date

### DIFF
--- a/infrastructure/db/dbgen/item.sql.go
+++ b/infrastructure/db/dbgen/item.sql.go
@@ -7,6 +7,7 @@ package dbgen
 
 import (
 	"context"
+
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -1568,12 +1569,13 @@ UPDATE review_dates r
 SET
     category_id = v.category_id,
     box_id = v.box_id,
+    initial_scheduled_date = v.initial_scheduled_date,
     scheduled_date = v.scheduled_date,
     is_completed = v.is_completed
 FROM
     UNNEST(
         $2::reviewdate_input[]
-    ) AS v(id, category_id, box_id, scheduled_date, is_completed)
+    ) AS v(id, category_id, box_id, initial_scheduled_date, scheduled_date, is_completed)
 WHERE
     r.id = v.id
 AND

--- a/infrastructure/db/query/item.sql
+++ b/infrastructure/db/query/item.sql
@@ -125,12 +125,13 @@ UPDATE review_dates r
 SET
     category_id = v.category_id,
     box_id = v.box_id,
+    initial_scheduled_date = v.initial_scheduled_date,
     scheduled_date = v.scheduled_date,
     is_completed = v.is_completed
 FROM
     UNNEST(
         sqlc.arg(input)::reviewdate_input[]
-    ) AS v(id, category_id, box_id, scheduled_date, is_completed)
+    ) AS v(id, category_id, box_id, initial_scheduled_date, scheduled_date, is_completed)
 WHERE
     r.id = v.id
 AND

--- a/infrastructure/repository/item_repository.go
+++ b/infrastructure/repository/item_repository.go
@@ -279,7 +279,7 @@ func (r *itemRepository) UpdateReviewDates(ctx context.Context, reviewdates []*i
 		if rd.BoxID != nil {
 			boxID = *rd.BoxID
 		}
-		inputs[i] = fmt.Sprintf("(%s,%s,%s,%s,%t)", rd.ReviewdateID, categoryID, boxID, rd.ScheduledDate.Format("2006-01-02"), rd.IsCompleted)
+		inputs[i] = fmt.Sprintf("(%s,%s,%s,%s,%s,%t)", rd.ReviewdateID, categoryID, boxID, rd.InitialScheduledDate.Format("2006-01-02"), rd.ScheduledDate.Format("2006-01-02"), rd.IsCompleted)
 	}
 
 	params := dbgen.UpdateReviewDatesParams{

--- a/migrations/000009_create_musics_table.up.sql
+++ b/migrations/000009_create_musics_table.up.sql
@@ -2,6 +2,7 @@ CREATE TYPE reviewdate_input AS (
     id uuid,
     category_id uuid,
     box_id uuid,
+    initial_scheduled_date date,
     scheduled_date date,
     is_completed boolean
 );


### PR DESCRIPTION
## 概要
learned_dateの変更時、　initial_scheduled_dateが新しい値で更新されるように修正

## 変更内容
**infrastructure/repository/item_repository.go**
1. `inputs[i]`に`rd.InitialScheduledDate.Format("2006-01-02")`も渡すように変更し、UNNEST式で扱えるように変更。

**migrations/000009_create_musics_table.up.sql**
1. 複合型`reviewdate_input`に`initial_scheduled_date date`を追加してUNNEST式に`initial_scheduled_date`を渡せるように変更。

**infrastructure/db/query/item.sql**
1. UNNEST式に`initial_scheduled_date`も受け取って更新するように変更。