### PR TITLE
bugfix: parsedToday.Equal(firstInCompletedScheduledDate)の時にnewReviewdatesを再生成していた不具合を修正

### DIFF
--- a/usecase/item/item_usecase.go
+++ b/usecase/item/item_usecase.go
@@ -902,7 +902,7 @@ func (iu *ItemUsecase) UpdateItemAsUnFinishedForce(ctx context.Context, input Up
 		return nil, err
 	}
 	var newReviewdates []*ItemDomain.Reviewdate
-	if parsedToday.Before(firstInCompletedScheduledDate) {
+	if parsedToday.Before(firstInCompletedScheduledDate) || parsedToday.Equal(firstInCompletedScheduledDate) {
 		shouldUpdateScheduledDates = false
 	} else {
 		shouldUpdateScheduledDates = true


### PR DESCRIPTION
## 概要
`UpdateItemAsUnFinishedForce`で再開させる復習物の復習日の中で最も古いis_completed=falseかつscheduled_date=todayなものが存在する時、`shouldUpdateScheduledDates`が`false`の時の分岐を通らず、`[]review_dates`を再生成する方の分岐を通っていたことによって`box_id`と`category_id`が`NULL`として更新されてしまう不具合の修正。。

## 変更内容
**不具合状況：**
 下記のように、条件式に`parsedToday.Equal(firstInCompletedScheduledDate)`が論理和で含まれておらず、リクエストには`box_id`と`category_id`が`NULL`なのに`[]review_dates`を再生成する処理を実行していたため、再開ボタンを押すだけで`is_completed=false`な`review_dates`の`box_id`と`category_id`がすべてNULLになってしまい、再開ボタンを押すと`category_id A`かつ`box_id A`の画面上からあるべきreview_datesが消えていた。
```go
if parsedToday.Before(firstInCompletedScheduledDate) {
		shouldUpdateScheduledDates = false
	}
```

**対応：**
この分岐に`parsedToday.Equal(firstInCompletedScheduledDate)`を論理和で追加し、不用意に復習日を再生成しないように修正。