### PR TITLE
Bug/#144/get all daily review dates response

### DIFF
--- a/controller/item/item_controller.go
+++ b/controller/item/item_controller.go
@@ -599,20 +599,21 @@ func (ic *itemController) GetAllDailyReviewDates(c echo.Context) error {
 			reviewDates := make([]DailyReviewDatesByBoxResponse, len(box.ReviewDates))
 			for k, rd := range box.ReviewDates {
 				reviewDates[k] = DailyReviewDatesByBoxResponse{
-					ReviewDateID:      rd.ReviewDateID,
-					CategoryID:        rd.CategoryID,
-					BoxID:             rd.BoxID,
-					StepNumber:        rd.StepNumber,
-					PrevScheduledDate: rd.PrevScheduledDate,
-					ScheduledDate:     rd.ScheduledDate,
-					NextScheduledDate: rd.NextScheduledDate,
-					IsCompleted:       rd.IsCompleted,
-					ItemID:            rd.ItemID,
-					ItemName:          rd.ItemName,
-					Detail:            rd.Detail,
-					LearnedDate:       rd.LearnedDate,
-					RegisteredAt:      rd.RegisteredAt,
-					EditedAt:          rd.EditedAt,
+					ReviewDateID:         rd.ReviewDateID,
+					CategoryID:           rd.CategoryID,
+					BoxID:                rd.BoxID,
+					StepNumber:           rd.StepNumber,
+					InitialScheduledDate: rd.InitialScheduledDate,
+					PrevScheduledDate:    rd.PrevScheduledDate,
+					ScheduledDate:        rd.ScheduledDate,
+					NextScheduledDate:    rd.NextScheduledDate,
+					IsCompleted:          rd.IsCompleted,
+					ItemID:               rd.ItemID,
+					ItemName:             rd.ItemName,
+					Detail:               rd.Detail,
+					LearnedDate:          rd.LearnedDate,
+					RegisteredAt:         rd.RegisteredAt,
+					EditedAt:             rd.EditedAt,
 				}
 			}
 			boxes[j] = DailyReviewDatesGroupedByBoxResponse{
@@ -627,19 +628,20 @@ func (ic *itemController) GetAllDailyReviewDates(c echo.Context) error {
 		unclassified := make([]UnclassifiedDailyReviewDatesGroupedByCategoryResponse, len(cat.UnclassifiedDailyReviewDatesByCategory))
 		for j, rd := range cat.UnclassifiedDailyReviewDatesByCategory {
 			unclassified[j] = UnclassifiedDailyReviewDatesGroupedByCategoryResponse{
-				ReviewDateID:      rd.ReviewDateID,
-				CategoryID:        rd.CategoryID,
-				StepNumber:        rd.StepNumber,
-				PrevScheduledDate: rd.PrevScheduledDate,
-				ScheduledDate:     rd.ScheduledDate,
-				NextScheduledDate: rd.NextScheduledDate,
-				IsCompleted:       rd.IsCompleted,
-				ItemID:            rd.ItemID,
-				ItemName:          rd.ItemName,
-				Detail:            rd.Detail,
-				LearnedDate:       rd.LearnedDate,
-				RegisteredAt:      rd.RegisteredAt,
-				EditedAt:          rd.EditedAt,
+				ReviewDateID:         rd.ReviewDateID,
+				CategoryID:           rd.CategoryID,
+				StepNumber:           rd.StepNumber,
+				InitialScheduledDate: rd.InitialScheduledDate,
+				PrevScheduledDate:    rd.PrevScheduledDate,
+				ScheduledDate:        rd.ScheduledDate,
+				NextScheduledDate:    rd.NextScheduledDate,
+				IsCompleted:          rd.IsCompleted,
+				ItemID:               rd.ItemID,
+				ItemName:             rd.ItemName,
+				Detail:               rd.Detail,
+				LearnedDate:          rd.LearnedDate,
+				RegisteredAt:         rd.RegisteredAt,
+				EditedAt:             rd.EditedAt,
 			}
 		}
 
@@ -655,18 +657,19 @@ func (ic *itemController) GetAllDailyReviewDates(c echo.Context) error {
 	userUnclassified := make([]UnclassifiedDailyReviewDatesGroupedByUserResponse, len(result.DailyReviewDatesGroupedByUser))
 	for i, rd := range result.DailyReviewDatesGroupedByUser {
 		userUnclassified[i] = UnclassifiedDailyReviewDatesGroupedByUserResponse{
-			ReviewDateID:      rd.ReviewDateID,
-			StepNumber:        rd.StepNumber,
-			PrevScheduledDate: rd.PrevScheduledDate,
-			ScheduledDate:     rd.ScheduledDate,
-			NextScheduledDate: rd.NextScheduledDate,
-			IsCompleted:       rd.IsCompleted,
-			ItemID:            rd.ItemID,
-			ItemName:          rd.ItemName,
-			Detail:            rd.Detail,
-			LearnedDate:       rd.LearnedDate,
-			RegisteredAt:      rd.RegisteredAt,
-			EditedAt:          rd.EditedAt,
+			ReviewDateID:         rd.ReviewDateID,
+			StepNumber:           rd.StepNumber,
+			InitialScheduledDate: rd.InitialScheduledDate,
+			PrevScheduledDate:    rd.PrevScheduledDate,
+			ScheduledDate:        rd.ScheduledDate,
+			NextScheduledDate:    rd.NextScheduledDate,
+			IsCompleted:          rd.IsCompleted,
+			ItemID:               rd.ItemID,
+			ItemName:             rd.ItemName,
+			Detail:               rd.Detail,
+			LearnedDate:          rd.LearnedDate,
+			RegisteredAt:         rd.RegisteredAt,
+			EditedAt:             rd.EditedAt,
 		}
 	}
 	res.DailyReviewDatesGroupedByUser = userUnclassified

--- a/controller/item/response.go
+++ b/controller/item/response.go
@@ -95,20 +95,21 @@ type UnclassifiedDailyDatesCountGroupedByCategoryResponse struct {
 }
 
 type DailyReviewDatesByBoxResponse struct {
-	ReviewDateID      string    `json:"review_date_id"`
-	CategoryID        string    `json:"category_id"`
-	BoxID             string    `json:"box_id"`
-	StepNumber        int       `json:"step_number"`
-	PrevScheduledDate *string   `json:"prev_scheduled_date"`
-	ScheduledDate     string    `json:"scheduled_date"`
-	NextScheduledDate *string   `json:"next_scheduled_date"`
-	IsCompleted       bool      `json:"is_completed"`
-	ItemID            string    `json:"item_id"`
-	ItemName          string    `json:"item_name"`
-	Detail            string    `json:"detail"`
-	LearnedDate       string    `json:"learned_date"`
-	RegisteredAt      time.Time `json:"registered_at"`
-	EditedAt          time.Time `json:"edited_at"`
+	ReviewDateID         string    `json:"review_date_id"`
+	CategoryID           string    `json:"category_id"`
+	BoxID                string    `json:"box_id"`
+	StepNumber           int       `json:"step_number"`
+	InitialScheduledDate string    `json:"initial_scheduled_date"`
+	PrevScheduledDate    *string   `json:"prev_scheduled_date"`
+	ScheduledDate        string    `json:"scheduled_date"`
+	NextScheduledDate    *string   `json:"next_scheduled_date"`
+	IsCompleted          bool      `json:"is_completed"`
+	ItemID               string    `json:"item_id"`
+	ItemName             string    `json:"item_name"`
+	Detail               string    `json:"detail"`
+	LearnedDate          string    `json:"learned_date"`
+	RegisteredAt         time.Time `json:"registered_at"`
+	EditedAt             time.Time `json:"edited_at"`
 }
 
 type DailyReviewDatesGroupedByBoxResponse struct {
@@ -120,19 +121,20 @@ type DailyReviewDatesGroupedByBoxResponse struct {
 }
 
 type UnclassifiedDailyReviewDatesGroupedByCategoryResponse struct {
-	ReviewDateID      string    `json:"review_date_id"`
-	CategoryID        string    `json:"category_id"`
-	StepNumber        int       `json:"step_number"`
-	PrevScheduledDate *string   `json:"prev_scheduled_date"`
-	ScheduledDate     string    `json:"scheduled_date"`
-	NextScheduledDate *string   `json:"next_scheduled_date"`
-	IsCompleted       bool      `json:"is_completed"`
-	ItemID            string    `json:"item_id"`
-	ItemName          string    `json:"item_name"`
-	Detail            string    `json:"detail"`
-	LearnedDate       string    `json:"learned_date"`
-	RegisteredAt      time.Time `json:"registered_at"`
-	EditedAt          time.Time `json:"edited_at"`
+	ReviewDateID         string    `json:"review_date_id"`
+	CategoryID           string    `json:"category_id"`
+	StepNumber           int       `json:"step_number"`
+	InitialScheduledDate string    `json:"initial_scheduled_date"`
+	PrevScheduledDate    *string   `json:"prev_scheduled_date"`
+	ScheduledDate        string    `json:"scheduled_date"`
+	NextScheduledDate    *string   `json:"next_scheduled_date"`
+	IsCompleted          bool      `json:"is_completed"`
+	ItemID               string    `json:"item_id"`
+	ItemName             string    `json:"item_name"`
+	Detail               string    `json:"detail"`
+	LearnedDate          string    `json:"learned_date"`
+	RegisteredAt         time.Time `json:"registered_at"`
+	EditedAt             time.Time `json:"edited_at"`
 }
 
 type DailyReviewDatesGroupedByCategoryResponse struct {
@@ -143,18 +145,19 @@ type DailyReviewDatesGroupedByCategoryResponse struct {
 }
 
 type UnclassifiedDailyReviewDatesGroupedByUserResponse struct {
-	ReviewDateID      string    `json:"review_date_id"`
-	StepNumber        int       `json:"step_number"`
-	PrevScheduledDate *string   `json:"prev_scheduled_date"`
-	ScheduledDate     string    `json:"scheduled_date"`
-	NextScheduledDate *string   `json:"next_scheduled_date"`
-	IsCompleted       bool      `json:"is_completed"`
-	ItemID            string    `json:"item_id"`
-	ItemName          string    `json:"item_name"`
-	Detail            string    `json:"detail"`
-	LearnedDate       string    `json:"learned_date"`
-	RegisteredAt      time.Time `json:"registered_at"`
-	EditedAt          time.Time `json:"edited_at"`
+	ReviewDateID         string    `json:"review_date_id"`
+	StepNumber           int       `json:"step_number"`
+	InitialScheduledDate string    `json:"initial_scheduled_date"`
+	PrevScheduledDate    *string   `json:"prev_scheduled_date"`
+	ScheduledDate        string    `json:"scheduled_date"`
+	NextScheduledDate    *string   `json:"next_scheduled_date"`
+	IsCompleted          bool      `json:"is_completed"`
+	ItemID               string    `json:"item_id"`
+	ItemName             string    `json:"item_name"`
+	Detail               string    `json:"detail"`
+	LearnedDate          string    `json:"learned_date"`
+	RegisteredAt         time.Time `json:"registered_at"`
+	EditedAt             time.Time `json:"edited_at"`
 }
 
 type GetDailyReviewDatesResponse struct {

--- a/domain/item/item_repository.go
+++ b/domain/item/item_repository.go
@@ -27,20 +27,21 @@ type UnclassifiedDailyDatesCountGroupedByCategory struct {
 }
 
 type DailyReviewDate struct {
-	ReviewdateID      string
-	CategoryID        *string
-	BoxID             *string
-	StepNumber        int
-	PrevScheduledDate *time.Time
-	ScheduledDate     time.Time
-	NextScheduledDate *time.Time
-	IsCompleted       bool
-	ItemID            string
-	Name              string
-	Detail            string
-	LearnedDate       time.Time
-	RegisteredAt      time.Time
-	EditedAt          time.Time
+	ReviewdateID         string
+	CategoryID           *string
+	BoxID                *string
+	StepNumber           int
+	InitialScheduledDate time.Time
+	PrevScheduledDate    *time.Time
+	ScheduledDate        time.Time
+	NextScheduledDate    *time.Time
+	IsCompleted          bool
+	ItemID               string
+	Name                 string
+	Detail               string
+	LearnedDate          time.Time
+	RegisteredAt         time.Time
+	EditedAt             time.Time
 }
 
 type IItemRepository interface {

--- a/infrastructure/db/dbgen/item.sql.go
+++ b/infrastructure/db/dbgen/item.sql.go
@@ -412,6 +412,7 @@ SELECT
     rd.category_id,
     rd.box_id,
     rd.step_number,
+    rd.initial_scheduled_date,
     rd.prev_scheduled_date,
     rd.scheduled_date,
     rd.next_scheduled_date,
@@ -429,6 +430,7 @@ FROM (
         box_id,
         item_id,
         step_number,
+        initial_scheduled_date,
         scheduled_date,
         is_completed,
         CAST(
@@ -466,20 +468,21 @@ type GetAllDailyReviewDatesParams struct {
 }
 
 type GetAllDailyReviewDatesRow struct {
-	ID                pgtype.UUID        `json:"id"`
-	CategoryID        pgtype.UUID        `json:"category_id"`
-	BoxID             pgtype.UUID        `json:"box_id"`
-	StepNumber        int16              `json:"step_number"`
-	PrevScheduledDate pgtype.Date        `json:"prev_scheduled_date"`
-	ScheduledDate     pgtype.Date        `json:"scheduled_date"`
-	NextScheduledDate pgtype.Date        `json:"next_scheduled_date"`
-	IsCompleted       bool               `json:"is_completed"`
-	ItemID            pgtype.UUID        `json:"item_id"`
-	Name              string             `json:"name"`
-	Detail            pgtype.Text        `json:"detail"`
-	LearnedDate       pgtype.Date        `json:"learned_date"`
-	RegisteredAt      pgtype.Timestamptz `json:"registered_at"`
-	EditedAt          pgtype.Timestamptz `json:"edited_at"`
+	ID                   pgtype.UUID        `json:"id"`
+	CategoryID           pgtype.UUID        `json:"category_id"`
+	BoxID                pgtype.UUID        `json:"box_id"`
+	StepNumber           int16              `json:"step_number"`
+	InitialScheduledDate pgtype.Date        `json:"initial_scheduled_date"`
+	PrevScheduledDate    pgtype.Date        `json:"prev_scheduled_date"`
+	ScheduledDate        pgtype.Date        `json:"scheduled_date"`
+	NextScheduledDate    pgtype.Date        `json:"next_scheduled_date"`
+	IsCompleted          bool               `json:"is_completed"`
+	ItemID               pgtype.UUID        `json:"item_id"`
+	Name                 string             `json:"name"`
+	Detail               pgtype.Text        `json:"detail"`
+	LearnedDate          pgtype.Date        `json:"learned_date"`
+	RegisteredAt         pgtype.Timestamptz `json:"registered_at"`
+	EditedAt             pgtype.Timestamptz `json:"edited_at"`
 }
 
 // LAG→item_idごとにstep_numberの昇順で並べた時、scheduled_dateが持つstep_numberより一個前のstep_numberのscheduled_dateを取得
@@ -499,6 +502,7 @@ func (q *Queries) GetAllDailyReviewDates(ctx context.Context, arg GetAllDailyRev
 			&i.CategoryID,
 			&i.BoxID,
 			&i.StepNumber,
+			&i.InitialScheduledDate,
 			&i.PrevScheduledDate,
 			&i.ScheduledDate,
 			&i.NextScheduledDate,

--- a/infrastructure/db/query/item.sql
+++ b/infrastructure/db/query/item.sql
@@ -524,6 +524,7 @@ SELECT
     rd.category_id,
     rd.box_id,
     rd.step_number,
+    rd.initial_scheduled_date,
     rd.prev_scheduled_date,
     rd.scheduled_date,
     rd.next_scheduled_date,
@@ -541,6 +542,7 @@ FROM (
         box_id,
         item_id,
         step_number,
+        initial_scheduled_date,
         scheduled_date,
         is_completed,
         CAST(

--- a/infrastructure/repository/item_repository.go
+++ b/infrastructure/repository/item_repository.go
@@ -950,6 +950,8 @@ func (r *itemRepository) GetAllDailyReviewDates(ctx context.Context, userID stri
 			boxID = &s
 		}
 
+		initialScheduledDate := row.InitialScheduledDate.Time
+
 		var prev *time.Time
 		if row.PrevScheduledDate.Valid {
 			t := row.PrevScheduledDate.Time
@@ -971,20 +973,21 @@ func (r *itemRepository) GetAllDailyReviewDates(ctx context.Context, userID stri
 		detail := row.Detail.String
 
 		results[i] = &itemDomain.DailyReviewDate{
-			ReviewdateID:      idStr,
-			CategoryID:        categoryID,
-			BoxID:             boxID,
-			StepNumber:        int(row.StepNumber),
-			PrevScheduledDate: prev,
-			ScheduledDate:     scheduled,
-			NextScheduledDate: next,
-			IsCompleted:       row.IsCompleted,
-			ItemID:            itemID,
-			Name:              row.Name,
-			Detail:            detail,
-			LearnedDate:       learnedDate,
-			RegisteredAt:      row.RegisteredAt.Time,
-			EditedAt:          row.EditedAt.Time,
+			ReviewdateID:         idStr,
+			CategoryID:           categoryID,
+			BoxID:                boxID,
+			StepNumber:           int(row.StepNumber),
+			InitialScheduledDate: initialScheduledDate,
+			PrevScheduledDate:    prev,
+			ScheduledDate:        scheduled,
+			NextScheduledDate:    next,
+			IsCompleted:          row.IsCompleted,
+			ItemID:               itemID,
+			Name:                 row.Name,
+			Detail:               detail,
+			LearnedDate:          learnedDate,
+			RegisteredAt:         row.RegisteredAt.Time,
+			EditedAt:             row.EditedAt.Time,
 		}
 	}
 

--- a/usecase/item/item_dto.go
+++ b/usecase/item/item_dto.go
@@ -241,14 +241,15 @@ type UnclassifiedDailyDatesCountGroupedByCategoryOutput struct {
 */
 
 type DailyReviewDatesByBoxOutput struct {
-	ReviewDateID      string
-	CategoryID        string // 必ず存在する
-	BoxID             string // 必ず存在する
-	StepNumber        int
-	PrevScheduledDate *string
-	ScheduledDate     string
-	NextScheduledDate *string
-	IsCompleted       bool
+	ReviewDateID         string
+	CategoryID           string // 必ず存在する
+	BoxID                string // 必ず存在する
+	StepNumber           int
+	InitialScheduledDate string
+	PrevScheduledDate    *string
+	ScheduledDate        string
+	NextScheduledDate    *string
+	IsCompleted          bool
 
 	// 復習物の情報
 	ItemID       string
@@ -268,13 +269,14 @@ type DailyReviewDatesGroupedByBoxOutput struct {
 }
 
 type UnclassifiedDailyReviewDatesGroupedByCategoryOutput struct {
-	ReviewDateID      string
-	CategoryID        string // 必ず存在する
-	StepNumber        int
-	PrevScheduledDate *string
-	ScheduledDate     string
-	NextScheduledDate *string
-	IsCompleted       bool
+	ReviewDateID         string
+	CategoryID           string // 必ず存在する
+	StepNumber           int
+	InitialScheduledDate string
+	PrevScheduledDate    *string
+	ScheduledDate        string
+	NextScheduledDate    *string
+	IsCompleted          bool
 
 	// 復習物の情報
 	ItemID       string
@@ -293,12 +295,13 @@ type DailyReviewDatesGroupedByCategoryOutput struct {
 }
 
 type UnclassifiedDailyReviewDatesGroupedByUserOutput struct {
-	ReviewDateID      string
-	StepNumber        int
-	PrevScheduledDate *string
-	ScheduledDate     string
-	NextScheduledDate *string
-	IsCompleted       bool
+	ReviewDateID         string
+	StepNumber           int
+	InitialScheduledDate string
+	PrevScheduledDate    *string
+	ScheduledDate        string
+	NextScheduledDate    *string
+	IsCompleted          bool
 
 	// 復習物の情報
 	ItemID       string

--- a/usecase/item/item_usecase.go
+++ b/usecase/item/item_usecase.go
@@ -1439,6 +1439,9 @@ func (iu *ItemUsecase) GetAllDailyReviewDates(ctx context.Context, userID string
 
 	// 8. 一つずつマッピングとグルーピング
 	for _, d := range dailyDates {
+
+		initialSched := d.InitialScheduledDate.Format("2006-01-02")
+
 		var prev, next *string
 		// ScheduledDateのstep_numberが1の時、PrevScheduledDateは存在しないという例を考慮してnil確認
 		if d.PrevScheduledDate != nil {
@@ -1458,18 +1461,19 @@ func (iu *ItemUsecase) GetAllDailyReviewDates(ctx context.Context, userID string
 		if d.CategoryID == nil && d.BoxID == nil {
 			out.DailyReviewDatesGroupedByUser = append(out.DailyReviewDatesGroupedByUser,
 				UnclassifiedDailyReviewDatesGroupedByUserOutput{
-					ReviewDateID:      d.ReviewdateID,
-					StepNumber:        d.StepNumber,
-					PrevScheduledDate: prev,
-					ScheduledDate:     sched,
-					NextScheduledDate: next,
-					IsCompleted:       d.IsCompleted,
-					ItemID:            d.ItemID,
-					ItemName:          d.Name,
-					Detail:            d.Detail,
-					LearnedDate:       learnedDate,
-					RegisteredAt:      d.RegisteredAt,
-					EditedAt:          d.EditedAt,
+					ReviewDateID:         d.ReviewdateID,
+					StepNumber:           d.StepNumber,
+					PrevScheduledDate:    prev,
+					InitialScheduledDate: initialSched,
+					ScheduledDate:        sched,
+					NextScheduledDate:    next,
+					IsCompleted:          d.IsCompleted,
+					ItemID:               d.ItemID,
+					ItemName:             d.Name,
+					Detail:               d.Detail,
+					LearnedDate:          learnedDate,
+					RegisteredAt:         d.RegisteredAt,
+					EditedAt:             d.EditedAt,
 				},
 			)
 			// 未分類の分岐を通った場合、その後のカテゴリー・ボックス振り分け処理は不要なのでcontinue
@@ -1502,19 +1506,20 @@ func (iu *ItemUsecase) GetAllDailyReviewDates(ctx context.Context, userID string
 		if d.BoxID == nil {
 			categoryGroup.UnclassifiedDailyReviewDatesByCategory = append(categoryGroup.UnclassifiedDailyReviewDatesByCategory,
 				UnclassifiedDailyReviewDatesGroupedByCategoryOutput{
-					ReviewDateID:      d.ReviewdateID,
-					CategoryID:        categoryID,
-					StepNumber:        d.StepNumber,
-					PrevScheduledDate: prev,
-					ScheduledDate:     sched,
-					NextScheduledDate: next,
-					IsCompleted:       d.IsCompleted,
-					ItemID:            d.ItemID,
-					ItemName:          d.Name,
-					Detail:            d.Detail,
-					LearnedDate:       learnedDate,
-					RegisteredAt:      d.RegisteredAt,
-					EditedAt:          d.EditedAt,
+					ReviewDateID:         d.ReviewdateID,
+					CategoryID:           categoryID,
+					StepNumber:           d.StepNumber,
+					InitialScheduledDate: initialSched,
+					PrevScheduledDate:    prev,
+					ScheduledDate:        sched,
+					NextScheduledDate:    next,
+					IsCompleted:          d.IsCompleted,
+					ItemID:               d.ItemID,
+					ItemName:             d.Name,
+					Detail:               d.Detail,
+					LearnedDate:          learnedDate,
+					RegisteredAt:         d.RegisteredAt,
+					EditedAt:             d.EditedAt,
 				},
 			)
 			// ボックス未分類の分岐を通った場合、その後のボックスグループ振り分け処理は不要なのでcontinue
@@ -1546,20 +1551,21 @@ func (iu *ItemUsecase) GetAllDailyReviewDates(ctx context.Context, userID string
 		// 今日の復習日データをボックスグループに追加
 		boxGroup.ReviewDates = append(boxGroup.ReviewDates,
 			DailyReviewDatesByBoxOutput{
-				ReviewDateID:      d.ReviewdateID,
-				CategoryID:        categoryID,
-				BoxID:             boxID,
-				StepNumber:        d.StepNumber,
-				PrevScheduledDate: prev,
-				ScheduledDate:     sched,
-				NextScheduledDate: next,
-				IsCompleted:       d.IsCompleted,
-				ItemID:            d.ItemID,
-				ItemName:          d.Name,
-				Detail:            d.Detail,
-				LearnedDate:       learnedDate,
-				RegisteredAt:      d.RegisteredAt,
-				EditedAt:          d.EditedAt,
+				ReviewDateID:         d.ReviewdateID,
+				CategoryID:           categoryID,
+				BoxID:                boxID,
+				StepNumber:           d.StepNumber,
+				InitialScheduledDate: initialSched,
+				PrevScheduledDate:    prev,
+				ScheduledDate:        sched,
+				NextScheduledDate:    next,
+				IsCompleted:          d.IsCompleted,
+				ItemID:               d.ItemID,
+				ItemName:             d.Name,
+				Detail:               d.Detail,
+				LearnedDate:          learnedDate,
+				RegisteredAt:         d.RegisteredAt,
+				EditedAt:             d.EditedAt,
 			},
 		)
 	}


### PR DESCRIPTION
# 概要
「今日の復習」の巻き戻し機能用に使う`initial_scheduled_date`を、`GetAllDailyReviewDates`のレスポンスの復習日毎に含めるように修正

## 背景
#144 

## 変更内容
1. 各層の`GetAllDailyReviewDates`メソッドのレスポンスの復習日毎（`ReviewDateID`毎）にInitialScheduledDateを含めるように変更。
2. `initial_scheduled_date`に伴いクエリも変更