### PR TITLE
Func/#147/encrypt email

### DIFF
--- a/domain/user/crypto.go
+++ b/domain/user/crypto.go
@@ -1,0 +1,74 @@
+package user
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+)
+
+type CryptoService struct {
+	key []byte
+}
+
+func NewCryptoService(hexKey string) (*CryptoService, error) {
+	key, err := hex.DecodeString(hexKey)
+	if err != nil {
+		return nil, fmt.Errorf("16進数の鍵のデコードに失敗しました: %w", err)
+	}
+	if len(key) != 32 {
+		return nil, fmt.Errorf("鍵のサイズが不正です: 32バイトである必要があります")
+	}
+	return &CryptoService{key: key}, nil
+}
+
+func (s *CryptoService) Encrypt(plaintext string) (string, error) {
+	block, err := aes.NewCipher(s.key)
+	if err != nil {
+		return "", err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
+	return hex.EncodeToString(ciphertext), nil
+}
+
+func (s *CryptoService) Decrypt(ciphertextHex string) (string, error) {
+	ciphertext, err := hex.DecodeString(ciphertextHex)
+	if err != nil {
+		return "", err
+	}
+
+	block, err := aes.NewCipher(s.key)
+	if err != nil {
+		return "", err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	if len(ciphertext) < gcm.NonceSize() {
+		return "", fmt.Errorf("暗号文が短すぎます")
+	}
+
+	nonce, ciphertext := ciphertext[:gcm.NonceSize()], ciphertext[gcm.NonceSize():]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return string(plaintext), nil
+}

--- a/domain/user/hasher.go
+++ b/domain/user/hasher.go
@@ -1,0 +1,27 @@
+package user
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+type Hasher struct {
+	key []byte
+}
+
+func NewHasher(hexKey string) (*Hasher, error) {
+	key, err := hex.DecodeString(hexKey) // 秘密鍵をバイト列に変換
+	if err != nil {
+		return nil, err
+	}
+	return &Hasher{key: key}, nil
+}
+
+// メールアドレスからユーザー検索用のキーを生成
+func (h *Hasher) GenerateSearchKey(email string) string {
+	//ハッシュ関数と秘密鍵を設定 → macにemailを書き込む → ハッシュ値算出→16進数文字列に変換してreturn
+	mac := hmac.New(sha256.New, h.key)
+	mac.Write([]byte(email))
+	return hex.EncodeToString(mac.Sum(nil)) // そこまでパフォは重要ではないのでnil
+}

--- a/domain/user/user_repository.go
+++ b/domain/user/user_repository.go
@@ -7,7 +7,7 @@ import (
 
 type UserRepository interface {
 	Create(ctx context.Context, user *User) error
-	FindByEmail(ctx context.Context, email string) (*User, error)
+	FindByEmailSearchKey(ctx context.Context, searchKey string) (*User, error)
 	GetSettingByID(ctx context.Context, userID string) (*User, error)
 	Update(ctx context.Context, user *User) error
 	UpdatePassword(ctx context.Context, userID, password string) error

--- a/infrastructure/db/dbgen/models.go
+++ b/infrastructure/db/dbgen/models.go
@@ -180,13 +180,14 @@ type ReviewPattern struct {
 }
 
 type User struct {
-	ID         pgtype.UUID        `json:"id"`
-	Email      string             `json:"email"`
-	Password   string             `json:"password"`
-	Timezone   string             `json:"timezone"`
-	ThemeColor ThemeColorEnum     `json:"theme_color"`
-	Language   string             `json:"language"`
-	VerifiedAt pgtype.Timestamptz `json:"verified_at"`
-	CreatedAt  pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
+	ID             pgtype.UUID        `json:"id"`
+	EmailSearchKey string             `json:"email_search_key"`
+	Email          string             `json:"email"`
+	Password       string             `json:"password"`
+	Timezone       string             `json:"timezone"`
+	ThemeColor     ThemeColorEnum     `json:"theme_color"`
+	Language       string             `json:"language"`
+	VerifiedAt     pgtype.Timestamptz `json:"verified_at"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
 }

--- a/infrastructure/db/dbgen/querier.go
+++ b/infrastructure/db/dbgen/querier.go
@@ -41,7 +41,7 @@ type Querier interface {
 	// 復習日のパターンIDがnilに変更されたとき
 	DeleteReviewDates(ctx context.Context, arg DeleteReviewDatesParams) error
 	FindEmailVerificationByUserID(ctx context.Context, userID pgtype.UUID) (FindEmailVerificationByUserIDRow, error)
-	FindUserByEmail(ctx context.Context, email string) (FindUserByEmailRow, error)
+	FindUserByEmailSearchKey(ctx context.Context, emailSearchKey string) (FindUserByEmailSearchKeyRow, error)
 	GetAllBoxesByCategoryID(ctx context.Context, arg GetAllBoxesByCategoryIDParams) ([]GetAllBoxesByCategoryIDRow, error)
 	GetAllCategoriesByUserID(ctx context.Context, userID pgtype.UUID) ([]GetAllCategoriesByUserIDRow, error)
 	// LAG→item_idごとにstep_numberの昇順で並べた時、scheduled_dateが持つstep_numberより一個前のstep_numberのscheduled_dateを取得

--- a/infrastructure/db/dbgen/user.sql.go
+++ b/infrastructure/db/dbgen/user.sql.go
@@ -15,6 +15,7 @@ const createUser = `-- name: CreateUser :exec
 INSERT INTO 
     users (
         id,
+        email_search_key,
         email,
         password,
         timezone,
@@ -26,22 +27,25 @@ INSERT INTO
         $3,
         $4,
         $5,
-        $6
+        $6,
+        $7
     )
 `
 
 type CreateUserParams struct {
-	ID         pgtype.UUID    `json:"id"`
-	Email      string         `json:"email"`
-	Password   string         `json:"password"`
-	Timezone   string         `json:"timezone"`
-	ThemeColor ThemeColorEnum `json:"theme_color"`
-	Language   string         `json:"language"`
+	ID             pgtype.UUID    `json:"id"`
+	EmailSearchKey string         `json:"email_search_key"`
+	Email          string         `json:"email"`
+	Password       string         `json:"password"`
+	Timezone       string         `json:"timezone"`
+	ThemeColor     ThemeColorEnum `json:"theme_color"`
+	Language       string         `json:"language"`
 }
 
 func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) error {
 	_, err := q.db.Exec(ctx, createUser,
 		arg.ID,
+		arg.EmailSearchKey,
 		arg.Email,
 		arg.Password,
 		arg.Timezone,
@@ -51,9 +55,10 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) error {
 	return err
 }
 
-const findUserByEmail = `-- name: FindUserByEmail :one
+const findUserByEmailSearchKey = `-- name: FindUserByEmailSearchKey :one
 SELECT
     id,
+    email,
     password,
     theme_color,
     language,
@@ -61,22 +66,24 @@ SELECT
 FROM
     users
 WHERE
-    email = $1
+    email_search_key = $1
 `
 
-type FindUserByEmailRow struct {
+type FindUserByEmailSearchKeyRow struct {
 	ID         pgtype.UUID        `json:"id"`
+	Email      string             `json:"email"`
 	Password   string             `json:"password"`
 	ThemeColor ThemeColorEnum     `json:"theme_color"`
 	Language   string             `json:"language"`
 	VerifiedAt pgtype.Timestamptz `json:"verified_at"`
 }
 
-func (q *Queries) FindUserByEmail(ctx context.Context, email string) (FindUserByEmailRow, error) {
-	row := q.db.QueryRow(ctx, findUserByEmail, email)
-	var i FindUserByEmailRow
+func (q *Queries) FindUserByEmailSearchKey(ctx context.Context, emailSearchKey string) (FindUserByEmailSearchKeyRow, error) {
+	row := q.db.QueryRow(ctx, findUserByEmailSearchKey, emailSearchKey)
+	var i FindUserByEmailSearchKeyRow
 	err := row.Scan(
 		&i.ID,
+		&i.Email,
 		&i.Password,
 		&i.ThemeColor,
 		&i.Language,
@@ -120,24 +127,27 @@ const updateUser = `-- name: UpdateUser :exec
 UPDATE
     users
 SET
-    email = $1,
-    timezone = $2,
-    theme_color = $3,
-    language = $4
+    email_search_key = $1,
+    email = $2,
+    timezone = $3,
+    theme_color = $4,
+    language = $5
 WHERE
-    id = $5
+    id = $6
 `
 
 type UpdateUserParams struct {
-	Email      string         `json:"email"`
-	Timezone   string         `json:"timezone"`
-	ThemeColor ThemeColorEnum `json:"theme_color"`
-	Language   string         `json:"language"`
-	ID         pgtype.UUID    `json:"id"`
+	EmailSearchKey string         `json:"email_search_key"`
+	Email          string         `json:"email"`
+	Timezone       string         `json:"timezone"`
+	ThemeColor     ThemeColorEnum `json:"theme_color"`
+	Language       string         `json:"language"`
+	ID             pgtype.UUID    `json:"id"`
 }
 
 func (q *Queries) UpdateUser(ctx context.Context, arg UpdateUserParams) error {
 	_, err := q.db.Exec(ctx, updateUser,
+		arg.EmailSearchKey,
 		arg.Email,
 		arg.Timezone,
 		arg.ThemeColor,

--- a/infrastructure/db/query/user.sql
+++ b/infrastructure/db/query/user.sql
@@ -2,6 +2,7 @@
 INSERT INTO 
     users (
         id,
+        email_search_key,
         email,
         password,
         timezone,
@@ -9,6 +10,7 @@ INSERT INTO
         language
     ) VALUES (
         sqlc.arg(id),
+        sqlc.arg(email_search_key),
         sqlc.arg(email),
         sqlc.arg(password),
         sqlc.arg(timezone),
@@ -16,9 +18,10 @@ INSERT INTO
         sqlc.arg(language)
     );
 
--- name: FindUserByEmail :one
+-- name: FindUserByEmailSearchKey :one
 SELECT
     id,
+    email,
     password,
     theme_color,
     language,
@@ -26,7 +29,7 @@ SELECT
 FROM
     users
 WHERE
-    email = sqlc.arg(email);
+    email_search_key = sqlc.arg(email_search_key);
 
 -- name: GetUserSettingByID :one
 SELECT
@@ -43,6 +46,7 @@ WHERE
 UPDATE
     users
 SET
+    email_search_key = sqlc.arg(email_search_key),
     email = sqlc.arg(email),
     timezone = sqlc.arg(timezone),
     theme_color = sqlc.arg(theme_color),

--- a/infrastructure/repository/user_repository.go
+++ b/infrastructure/repository/user_repository.go
@@ -29,21 +29,22 @@ func (r *userRepository) Create(ctx context.Context, u *userDomain.User) error {
 	pgID := pgtype.UUID{Bytes: parsed, Valid: true}
 
 	params := dbgen.CreateUserParams{
-		ID:         pgID,
-		Email:      u.Email,
-		Password:   u.EncryptedPassword,
-		Timezone:   u.Timezone,
-		ThemeColor: dbgen.ThemeColorEnum(u.ThemeColor),
-		Language:   u.Language,
+		ID:             pgID,
+		EmailSearchKey: u.EmailSearchKey,
+		Email:          u.EncryptedEmail,
+		Password:       u.EncryptedPassword,
+		Timezone:       u.Timezone,
+		ThemeColor:     dbgen.ThemeColorEnum(u.ThemeColor),
+		Language:       u.Language,
 	}
 
 	return q.CreateUser(ctx, params)
 }
 
-func (r *userRepository) FindByEmail(ctx context.Context, email string) (*userDomain.User, error) {
+func (r *userRepository) FindByEmailSearchKey(ctx context.Context, searchKey string) (*userDomain.User, error) {
 	q := db.GetQuery(ctx)
 
-	row, err := q.FindUserByEmail(ctx, email)
+	row, err := q.FindUserByEmailSearchKey(ctx, searchKey)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +62,7 @@ func (r *userRepository) FindByEmail(ctx context.Context, email string) (*userDo
 
 	return &userDomain.User{
 		ID:                id,
-		Email:             email,
+		EncryptedEmail:    row.Email,
 		EncryptedPassword: row.Password,
 		ThemeColor:        string(row.ThemeColor),
 		Language:          row.Language,
@@ -107,11 +108,12 @@ func (r *userRepository) Update(ctx context.Context, u *userDomain.User) error {
 	pgID := pgtype.UUID{Bytes: parsed, Valid: true}
 
 	params := dbgen.UpdateUserParams{
-		Email:      u.Email,
-		Timezone:   u.Timezone,
-		ThemeColor: dbgen.ThemeColorEnum(u.ThemeColor),
-		Language:   u.Language,
-		ID:         pgID,
+		EmailSearchKey: u.EmailSearchKey,
+		Email:          u.EncryptedEmail,
+		Timezone:       u.Timezone,
+		ThemeColor:     dbgen.ThemeColorEnum(u.ThemeColor),
+		Language:       u.Language,
+		ID:             pgID,
 	}
 
 	return q.UpdateUser(ctx, params)

--- a/migrations/000001_create_users_table.up.sql
+++ b/migrations/000001_create_users_table.up.sql
@@ -2,7 +2,8 @@ CREATE TYPE theme_color_enum AS ENUM ('dark', 'light');
 
 CREATE TABLE users (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    email VARCHAR(255) NOT NULL UNIQUE,
+    email_search_key TEXT NOT NULL UNIQUE,
+    email TEXT NOT NULL UNIQUE,
     password TEXT NOT NULL,
     timezone VARCHAR(64) NOT NULL,
     theme_color theme_color_enum NOT NULL,

--- a/usecase/user/user_helpers.go
+++ b/usecase/user/user_helpers.go
@@ -67,7 +67,7 @@ func (uu *userUsecase) createLoginResponse(user *userDomain.User) (*LoginUserOut
 
 // 未認証ユーザーに認証コードを再送信
 func (uu *userUsecase) resendVerification(ctx context.Context, userID string, dto CreateUserInput) (*CreateUserOutput, error) {
-	newUser, err := userDomain.NewUser(userID, dto.Email, dto.Password, dto.Timezone, dto.ThemeColor, dto.Language)
+	newUser, err := userDomain.NewUser(userID, dto.Email, dto.Password, dto.Timezone, dto.ThemeColor, dto.Language, uu.cryptoService, uu.hasher)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +95,8 @@ func (uu *userUsecase) resendVerification(ctx context.Context, userID string, dt
 		}
 
 		// メール送信処理
-		if err := uu.sendVerificationEmail(newUser.Language, newUser.Email, code); err != nil {
-			fmt.Printf("警告: %s への認証メールの再送信に失敗しました: %v\n", newUser.Email, err)
+		if err := uu.sendVerificationEmail(newUser.Language, dto.Email, code); err != nil {
+			fmt.Printf("警告: %s への認証メールの再送信に失敗しました: %v\n", dto.Email, err)
 		}
 
 		return nil
@@ -108,6 +108,6 @@ func (uu *userUsecase) resendVerification(ctx context.Context, userID string, dt
 
 	return &CreateUserOutput{
 		ID:    newUser.ID,
-		Email: newUser.Email,
+		Email: dto.Email,
 	}, nil
 }


### PR DESCRIPTION
## 概要
メールアドレスを暗号化して永続化するように変更

## 変更内容
1.  **メールアドレスの保存方式の変更**
    - `users`テーブルの`email`カラムを廃止し、新たに以下の2つのカラムを追加。
        - `encrypted_email`：今後バッチ処理でメール送信する機能を追加する予定なので復号化可能にした。
        - `email_search_key`：単なるユーザーの存在判定に使うので復号化の必要はない。

2.  **暗号化、ハッシュ化サービスの追加**
    - メールアドレスの暗号化、復号化を行う`CryptoService`を定義、実装。
    - 検索キーを生成するための`Hasher`サービスの定義、実装。
    - `CryptoService`と`Hasher`は`userUsecase`にDI。

4.  **各機能の修正**
    - ユーザー存在確認には、既存の「emailの比較」の方法から、入力されたメールアドレスから`email_search_key`を生成し、その値でユーザー検索する方法に変更。AES-GCMだと毎回違う値が生成されるので暗号化されたemailは検索キーとしては使えない。そのため、毎回同じ値が得られるHMAC-SHA256を使って、emailと秘密鍵でハッシュ値を算出し、その値でユーザー検索をする方法にした。
    - 既存のメール送信機能は一貫してリクエストに含まれているemailをそのまま使って送信するように変更（リクエストの値が常に正しいので、本物のデータを復号化する必要がない）
