### PR TITLE
Fix/#155/add ci checker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,17 @@ jobs:
         with:
           version: v2.2.2
           args: --timeout=3m
+
+      - name: Checkout Source
+        uses: actions/checkout@v3
+
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: ./...
+
+      - id: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-file: go.mod
+          go-package: ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,14 +30,6 @@ jobs:
           version: v2.2.2
           args: --timeout=3m
 
-      - name: Checkout Source
-        uses: actions/checkout@v3
-
-      - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
-        with:
-          args: ./...
-
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,3 +7,4 @@ linters:
     - staticcheck
     - unused
     - errcheck
+    - gosec

--- a/infrastructure/db/dbgen/user.sql.go
+++ b/infrastructure/db/dbgen/user.sql.go
@@ -157,6 +157,7 @@ func (q *Queries) UpdateUser(ctx context.Context, arg UpdateUserParams) error {
 	return err
 }
 
+// #nosec G101
 const updateUserPassword = `-- name: UpdateUserPassword :exec
 UPDATE
     users

--- a/infrastructure/repository/item_repository.go
+++ b/infrastructure/repository/item_repository.go
@@ -102,7 +102,7 @@ func (r *itemRepository) CreateReviewdates(ctx context.Context, reviewdates []*i
 			CategoryID:           pgCategoryID,
 			BoxID:                pgBoxID,
 			ItemID:               pgItemID,
-			StepNumber:           int16(rd.StepNumber),
+			StepNumber:           int16(rd.StepNumber), // #nosec G115
 			InitialScheduledDate: pgtype.Date{Time: rd.InitialScheduledDate, Valid: true},
 			ScheduledDate:        pgtype.Date{Time: rd.ScheduledDate, Valid: true},
 			IsCompleted:          rd.IsCompleted,

--- a/infrastructure/repository/pattern_repository.go
+++ b/infrastructure/repository/pattern_repository.go
@@ -51,8 +51,8 @@ func (r *patternRepository) CreatePatternSteps(ctx context.Context, steps []*pat
 			ID:           pgStepID,
 			UserID:       pgUserID,
 			PatternID:    pgPatternID,
-			StepNumber:   int16(s.StepNumber),
-			IntervalDays: int16(s.IntervalDays),
+			StepNumber:   int16(s.StepNumber),   // #nosec G115
+			IntervalDays: int16(s.IntervalDays), // #nosec G115
 		}
 		rows[i] = []any{
 			cps[i].ID,


### PR DESCRIPTION
## 概要
- govulncheckで依存関係の中に既知の脆弱性があるか検知するCIの導入
- gosecで簡易的なセキュリティチェックを導入（golangci-lint）
- gosecの誤検出を除外。
  - int16型の部分（interval_daysとstep_number）は32768文字以上は想定していない（DBではなるべく小さい型を使いたい）ので除外（#nosec G115）
  - クエリのカラム「password」をハードコードされていると誤検出していたので除外（#nosec G101）